### PR TITLE
Add cross-language package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,140 @@
+name: Publish
+
+on:
+  push:
+    tags:
+    - v*
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Package version to validate, build, and optionally publish
+        required: true
+        type: string
+      dry_run:
+        description: Build and test packages without publishing
+        required: true
+        default: true
+        type: boolean
+
+env:
+  RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+  DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate release version
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Check package versions
+      shell: pwsh
+      run: ./scripts/Publish.ps1 -Package Validate -Version $env:RELEASE_VERSION
+
+  node:
+    name: Publish Node package
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
+      with:
+        node-version: 24
+        registry-url: https://registry.npmjs.org
+    - name: Publish
+      shell: pwsh
+      run: ./scripts/Publish.ps1 -Package Node -Version $env:RELEASE_VERSION -SkipPublish:([bool]::Parse($env:DRY_RUN))
+
+  dotnet:
+    name: Publish .NET package
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: nuget
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - uses: actions/checkout@v7
+    - uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0.x
+    - name: Log in to NuGet
+      if: env.DRY_RUN != 'true'
+      id: nuget-login
+      uses: NuGet/login@v1
+      with:
+        user: ${{ vars.NUGET_USER }}
+    - name: Publish
+      shell: pwsh
+      env:
+        NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+      run: ./scripts/Publish.ps1 -Package DotNet -Version $env:RELEASE_VERSION -SkipPublish:([bool]::Parse($env:DRY_RUN))
+
+  powershell:
+    name: Publish PowerShell module
+    needs: [validate, dotnet]
+    runs-on: ubuntu-latest
+    environment: psgallery
+    steps:
+    - uses: actions/checkout@v7
+    - uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0.x
+    - name: Install PowerShell 7.6
+      shell: bash
+      run: dotnet tool install --global PowerShell --version '7.6.*'
+    - name: Install Pester
+      shell: bash
+      run: ~/.dotnet/tools/pwsh -NoProfile -Command 'Install-Module Pester -MinimumVersion 5.7.1 -Scope CurrentUser -Force'
+    - name: Publish
+      shell: bash
+      env:
+        PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
+        RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+        DRY_RUN: ${{ env.DRY_RUN }}
+      run: ~/.dotnet/tools/pwsh -NoProfile -Command '& ./scripts/Publish.ps1 -Package PowerShell -Version $env:RELEASE_VERSION -SkipPublish:([bool]::Parse($env:DRY_RUN))'
+
+  python:
+    name: Publish Python packages
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - uses: actions/checkout@v7
+    - uses: actions/setup-python@v7
+      with:
+        python-version: '3.14'
+    - name: Build and test
+      shell: pwsh
+      run: ./scripts/Publish.ps1 -Package Python -Version $env:RELEASE_VERSION -SkipPublish
+    - name: Publish
+      if: env.DRY_RUN != 'true'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: artifacts/python
+
+  go:
+    name: Publish Go module tags
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-go@v7
+      with:
+        go-version-file: packages/go/go.mod
+    - name: Publish
+      shell: pwsh
+      run: ./scripts/Publish.ps1 -Package Go -Version $env:RELEASE_VERSION -CommitSha '${{ github.sha }}' -SkipPublish:([bool]::Parse($env:DRY_RUN))

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Logs
 logs
+artifacts/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,3 +170,7 @@ Project conventions:
 - Review and update the checked-in public API baseline for intentional API changes.
 - Update user documentation when public APIs or supported behavior change.
 - Add or update the native test-framework sample when user-facing workflows change.
+
+## Publishing
+
+Packages are released together using one semantic-version Git tag and protected registry environments. See [Publishing packages](docs/publishing.md) for registry configuration, version sources, dependency order, and the release checklist.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,59 @@
+# Publishing packages
+
+All packages are released together from one repository tag. Pushing a semantic-version tag such as `v0.1.0` starts `.github/workflows/publish.yml`, which verifies the tag against every package manifest, runs the package tests and public API checks, builds the artifacts, and publishes through protected GitHub environments.
+
+The workflow delegates package behavior to `scripts/Publish.ps1`. Select a release unit with `-Package Validate`, `Node`, `DotNet`, `PowerShell`, `Python`, or `Go`, and pass the shared version with `-Version`. The `Python` selector builds both Python distributions together. Use `-SkipPublish` to run validation, tests, and packaging without uploading or creating tags:
+
+```powershell
+./scripts/Publish.ps1 -Package Node -Version 0.1.0 -SkipPublish
+```
+
+For Python, the script builds both distributions into `artifacts/python`, and one workflow action uploads them together so trusted publishing can use GitHub's OIDC identity.
+
+To exercise the complete release pipeline without publishing, run the **Publish** workflow manually, enter the package version, and leave **dry_run** enabled. Dry-run jobs perform version checks, tests, API checks, and package builds, but skip registry authentication, uploads, and Go tag creation. Tag-triggered runs publish normally.
+
+## One-time registry setup
+
+Create the `npm`, `nuget`, `pypi`, and `psgallery` environments in the GitHub repository. Add required reviewers to each environment so that a tag cannot publish without approval.
+
+| Environment | Registry configuration |
+| --- | --- |
+| `npm` | On npmjs.com, configure a trusted publisher for package `@anthonycmartin/bicep-testing`, this repository, workflow `publish.yml`, and environment `npm`. No long-lived token is required. |
+| `nuget` | On nuget.org, configure a trusted publishing policy for package `AnthonyCMartin.BicepTesting`, this repository, workflow `publish.yml`, and environment `nuget`. Add the policy's nuget.org username as the GitHub environment variable `NUGET_USER`. |
+| `pypi` | On PyPI, configure trusted publishers for `anthonycmartin-bicep-testing` and `bicep_rpc_client`, both using this repository, workflow `publish.yml`, and environment `pypi`. No long-lived token is required. |
+| `psgallery` | Add a PowerShell Gallery API key as the GitHub environment secret `PSGALLERY_API_KEY`. Scope and rotate the key according to the Gallery account policy. |
+
+The Go proxy requires path-prefixed tags for modules in subdirectories. The workflow creates those compatibility tags automatically from the repository release tag; release authors still create only one tag.
+
+## Prepare a release
+
+1. Update every package manifest to the same version and update dependency constraints in a pull request.
+2. Add release notes to the pull request and update user documentation if installation or behavior changed.
+3. Run the normal tests, public API check, and package build locally.
+4. Merge the pull request before creating the tag. Tags must point to commits on `main`.
+5. Create and push one annotated `vX.Y.Z` tag.
+6. Approve the protected GitHub environment deployments and verify every package on its registry.
+
+| Release unit | Version source |
+| --- | --- |
+| Node | `packages/node/package.json` and `package-lock.json` |
+| .NET | `packages/dotnet/src/BicepTest/BicepTest.csproj` |
+| PowerShell | `packages/powershell/AnthonyCMartin.BicepTesting/AnthonyCMartin.BicepTesting.psd1` |
+| Python test library | `packages/python/pyproject.toml` |
+| Python RPC client | `packages/python/bicep_rpc_client/pyproject.toml` |
+| Go test library and RPC client | Repository tag, converted to path-prefixed tags by the workflow |
+
+For example:
+
+```sh
+git switch main
+git pull --ff-only
+git tag -a v0.1.0 -m "Release v0.1.0"
+git push origin v0.1.0
+```
+
+Registry versions are immutable. If publishing succeeds but a later verification step fails, fix the issue and release a new patch version rather than reusing the tag.
+
+## Dependency order
+
+The workflow publishes both Python distributions together and the .NET package before the PowerShell module. It creates both Go module tags after testing both modules. Keep the root Go module requirement aligned with the shared release version; the local `replace` directive supports monorepo development and is ignored by consumers.

--- a/packages/dotnet/src/BicepTest/BicepTest.csproj
+++ b/packages/dotnet/src/BicepTest/BicepTest.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>AnthonyCMartin.BicepTesting</PackageId>
+    <Version>0.1.0</Version>
     <AssemblyName>AnthonyCMartin.BicepTesting</AssemblyName>
     <RootNamespace>AnthonyCMartin.BicepTesting</RootNamespace>
     <Description>Test library for interacting with the Bicep CLI.</Description>

--- a/packages/go/go.mod
+++ b/packages/go/go.mod
@@ -5,7 +5,7 @@ go 1.24
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeploymentstacks v1.0.1
-	github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client v0.0.0
+	github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client v0.1.0
 )
 
 require (

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonycmartin/bicep-testing",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonycmartin/bicep-testing",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@azure/arm-resourcesdeploymentstacks": "^2.0.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonycmartin/bicep-testing",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Test library for interacting with the Bicep CLI.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "prepack": "npm run build",
     "test": "jest",
     "api:update": "npm run build && node scripts/public-api.mjs --update",
     "api:check": "npm run build && node scripts/public-api.mjs --check",
@@ -28,6 +29,10 @@
   ],
   "author": "Anthony Martin",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "bugs": {
     "url": "https://github.com/anthony-c-martin/bicep-testing/issues"
   },

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -1,0 +1,11 @@
+# Bicep Testing for Python
+
+`anthonycmartin-bicep-testing` evaluates Bicep deployment snapshots locally and supports opt-in live deployment tests through idiomatic Python APIs.
+
+## Install
+
+```sh
+python -m pip install anthonycmartin-bicep-testing
+```
+
+See the [Python documentation](https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/python.md) for usage and lifecycle examples.

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "anthonycmartin-bicep-testing"
 version = "0.1.0"
 description = "Test Bicep infrastructure by evaluating deployment snapshots locally."
+readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
 authors = [{ name = "Anthony Martin" }]
@@ -13,6 +14,11 @@ dependencies = [
 	"bicep_rpc_client>=0.1.0",
 	"azure-mgmt-resource-deploymentstacks==1.0.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/anthony-c-martin/bicep-testing"
+Repository = "https://github.com/anthony-c-martin/bicep-testing"
+Issues = "https://github.com/anthony-c-martin/bicep-testing/issues"
 
 [project.optional-dependencies]
 test = ["pytest>=8.0"]

--- a/samples/go/go.mod
+++ b/samples/go/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeploymentstacks v1.0.1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client v0.0.0 // indirect
+	github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client v0.1.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/scripts/Publish.ps1
+++ b/scripts/Publish.ps1
@@ -1,0 +1,207 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('Validate', 'Node', 'DotNet', 'PowerShell', 'Python', 'Go')]
+    [string] $Package,
+
+    [Parameter(Mandatory)]
+    [string] $Version,
+
+    [switch] $SkipPublish,
+
+    [string] $CommitSha
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3.0
+
+$repositoryRoot = Split-Path $PSScriptRoot -Parent
+$releaseVersion = $Version -replace '^v', ''
+if ($releaseVersion -notmatch '^\d+\.\d+\.\d+$') {
+    throw "Version must have the form X.Y.Z or vX.Y.Z, got '$Version'."
+}
+
+function Invoke-NativeCommand {
+    param(
+        [Parameter(Mandatory)]
+        [string] $FilePath,
+
+        [Parameter()]
+        [string[]] $ArgumentList = @()
+    )
+
+    & $FilePath @ArgumentList
+    if ($LASTEXITCODE -ne 0) {
+        throw "$FilePath failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Assert-Version {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Name,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string] $Actual
+    )
+
+    if ($Actual -ne $releaseVersion) {
+        throw "$Name version '$Actual' does not match release version '$releaseVersion'."
+    }
+}
+
+function Test-AllVersions {
+    $node = Get-Content (Join-Path $repositoryRoot 'packages/node/package.json') -Raw | ConvertFrom-Json
+    $nodeLock = Get-Content (Join-Path $repositoryRoot 'packages/node/package-lock.json') -Raw | ConvertFrom-Json -AsHashtable
+    [xml] $dotnet = Get-Content (Join-Path $repositoryRoot 'packages/dotnet/src/BicepTest/BicepTest.csproj') -Raw
+    $powerShellManifest = Import-PowerShellDataFile (Join-Path $repositoryRoot 'packages/powershell/AnthonyCMartin.BicepTesting/AnthonyCMartin.BicepTesting.psd1')
+    $pythonContent = Get-Content (Join-Path $repositoryRoot 'packages/python/pyproject.toml') -Raw
+    $pythonRpcContent = Get-Content (Join-Path $repositoryRoot 'packages/python/bicep_rpc_client/pyproject.toml') -Raw
+    $goMod = Get-Content (Join-Path $repositoryRoot 'packages/go/go.mod') -Raw
+
+    Assert-Version 'Node' $node.version
+    Assert-Version 'Node lockfile' $nodeLock.version
+    Assert-Version 'Node lockfile root package' $nodeLock.packages[''].version
+    Assert-Version '.NET' $dotnet.Project.PropertyGroup.Version
+    Assert-Version 'PowerShell' $powerShellManifest.ModuleVersion
+    Assert-Version 'Python' ([regex]::Match($pythonContent, '(?m)^version = "([^"]+)"$').Groups[1].Value)
+    Assert-Version 'Python RPC client' ([regex]::Match($pythonRpcContent, '(?m)^version = "([^"]+)"$').Groups[1].Value)
+    Assert-Version 'Go RPC dependency' ([regex]::Match($goMod, 'bicep-rpc-client\s+v([^\s]+)').Groups[1].Value)
+
+    Write-Host "Every package is ready for v$releaseVersion."
+}
+
+function Publish-NodePackage {
+    Push-Location (Join-Path $repositoryRoot 'packages/node')
+    try {
+        Invoke-NativeCommand npm @('ci', '--legacy-peer-deps')
+        Invoke-NativeCommand npm @('test')
+        Invoke-NativeCommand npm @('run', 'api:check')
+        $actualVersion = & node -p "require('./package.json').version"
+        if ($LASTEXITCODE -ne 0) { throw 'Unable to read the Node package version.' }
+        Assert-Version 'Node' $actualVersion
+        if (-not $SkipPublish) {
+            Invoke-NativeCommand npm @('publish')
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Publish-DotNetPackage {
+    $project = Join-Path $repositoryRoot 'packages/dotnet/src/BicepTest/BicepTest.csproj'
+    $solution = Join-Path $repositoryRoot 'packages/dotnet/BicepTest.slnx'
+    $output = Join-Path $repositoryRoot 'artifacts/dotnet'
+    $actualVersion = & dotnet msbuild $project '-getProperty:Version' '-nologo'
+    if ($LASTEXITCODE -ne 0) { throw 'Unable to read the .NET package version.' }
+    Assert-Version '.NET' $actualVersion
+    Invoke-NativeCommand dotnet @('test', $solution, '--configuration', 'Release')
+    Invoke-NativeCommand dotnet @('pack', $project, '--configuration', 'Release', "-p:PackageOutputPath=$output", '-p:ContinuousIntegrationBuild=true')
+    if (-not $SkipPublish) {
+        if ([string]::IsNullOrWhiteSpace($env:NUGET_API_KEY)) {
+            throw 'NUGET_API_KEY is required to publish the .NET package.'
+        }
+        Get-ChildItem $output -Filter '*.nupkg' | ForEach-Object {
+            Invoke-NativeCommand dotnet @('nuget', 'push', $_.FullName, '--api-key', $env:NUGET_API_KEY, '--source', 'https://api.nuget.org/v3/index.json')
+        }
+    }
+}
+
+function Publish-PowerShellPackage {
+    $manifestPath = Join-Path $repositoryRoot 'packages/powershell/AnthonyCMartin.BicepTesting/AnthonyCMartin.BicepTesting.psd1'
+    $modulePath = Split-Path $manifestPath -Parent
+    Assert-Version 'PowerShell' (Import-PowerShellDataFile $manifestPath).ModuleVersion
+    & (Join-Path $repositoryRoot 'packages/powershell/build.ps1')
+    Invoke-Pester (Join-Path $repositoryRoot 'packages/powershell/test') -CI
+    & (Join-Path $repositoryRoot 'packages/powershell/scripts/public-api.ps1') -Check
+    if (-not $SkipPublish) {
+        if ([string]::IsNullOrWhiteSpace($env:PSGALLERY_API_KEY)) {
+            throw 'PSGALLERY_API_KEY is required to publish the PowerShell module.'
+        }
+        Publish-Module -Path $modulePath -NuGetApiKey $env:PSGALLERY_API_KEY -Repository PSGallery
+    }
+}
+
+function Publish-PythonPackages {
+    Invoke-NativeCommand python @('-m', 'pip', 'install', 'build', '-e', "$(Join-Path $repositoryRoot 'packages/python/bicep_rpc_client')[test]", '-e', "$(Join-Path $repositoryRoot 'packages/python')[test]")
+    Invoke-NativeCommand python @('-m', 'pytest', (Join-Path $repositoryRoot 'packages/python/tests'), (Join-Path $repositoryRoot 'packages/python/bicep_rpc_client/tests'))
+    Invoke-NativeCommand python @((Join-Path $repositoryRoot 'packages/python/scripts/public_api.py'), '--check')
+
+    $projectDirectory = Join-Path $repositoryRoot 'packages/python'
+    $rpcProjectDirectory = Join-Path $projectDirectory 'bicep_rpc_client'
+    $distributionDirectory = Join-Path $repositoryRoot 'artifacts/python'
+    $pyproject = Get-Content (Join-Path $projectDirectory 'pyproject.toml') -Raw
+    $rpcPyproject = Get-Content (Join-Path $rpcProjectDirectory 'pyproject.toml') -Raw
+    Assert-Version 'Python' ([regex]::Match($pyproject, '(?m)^version = "([^"]+)"$').Groups[1].Value)
+    Assert-Version 'Python RPC client' ([regex]::Match($rpcPyproject, '(?m)^version = "([^"]+)"$').Groups[1].Value)
+    Remove-Item $distributionDirectory -Recurse -Force -ErrorAction SilentlyContinue
+    Invoke-NativeCommand python @('-m', 'build', $rpcProjectDirectory, '--outdir', $distributionDirectory)
+    Invoke-NativeCommand python @('-m', 'build', $projectDirectory, '--outdir', $distributionDirectory)
+}
+
+function Publish-GoPackages {
+    $rootModuleDirectory = Join-Path $repositoryRoot 'packages/go'
+    $rpcModuleDirectory = Join-Path $rootModuleDirectory 'bicep-rpc-client'
+    Push-Location $rootModuleDirectory
+    try {
+        Invoke-NativeCommand go @('test', './...')
+        Invoke-NativeCommand go @('run', './internal/apidoc', '--check')
+        $rootModule = & go list -m
+        if ($LASTEXITCODE -ne 0) { throw 'Unable to read the root Go module path.' }
+    }
+    finally {
+        Pop-Location
+    }
+    Push-Location $rpcModuleDirectory
+    try {
+        Invoke-NativeCommand go @('test', './...')
+        $rpcModule = & go list -m
+        if ($LASTEXITCODE -ne 0) { throw 'Unable to read the RPC Go module path.' }
+    }
+    finally {
+        Pop-Location
+    }
+
+    if ($rootModule -ne 'github.com/anthony-c-martin/bicep-testing/packages/go') {
+        throw "Unexpected root Go module path: $rootModule"
+    }
+    if ($rpcModule -ne 'github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client') {
+        throw "Unexpected RPC Go module path: $rpcModule"
+    }
+    if ($SkipPublish) { return }
+
+    if ([string]::IsNullOrWhiteSpace($CommitSha)) {
+        $CommitSha = & git -C $repositoryRoot rev-parse HEAD
+        if ($LASTEXITCODE -ne 0) { throw 'Unable to determine the release commit.' }
+    }
+    $tags = @(
+        @{ Name = "packages/go/bicep-rpc-client/v$releaseVersion"; Message = "Release Go RPC client v$releaseVersion" }
+        @{ Name = "packages/go/v$releaseVersion"; Message = "Release Go test library v$releaseVersion" }
+    )
+    foreach ($tag in $tags) {
+        & git -C $repositoryRoot rev-parse --quiet --verify "refs/tags/$($tag.Name)" *> $null
+        if ($LASTEXITCODE -eq 0) {
+            throw "Tag $($tag.Name) already exists."
+        }
+    }
+    Invoke-NativeCommand git @('-C', $repositoryRoot, 'config', 'user.name', 'github-actions[bot]')
+    Invoke-NativeCommand git @('-C', $repositoryRoot, 'config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com')
+    foreach ($tag in $tags) {
+        Invoke-NativeCommand git @('-C', $repositoryRoot, 'tag', '-a', $tag.Name, $CommitSha, '-m', $tag.Message)
+    }
+    Invoke-NativeCommand git @('-C', $repositoryRoot, 'push', 'origin', "refs/tags/$($tags[0].Name)", "refs/tags/$($tags[1].Name)")
+}
+
+Set-Location $repositoryRoot
+switch ($Package) {
+    'Validate' { Test-AllVersions }
+    'Node' { Publish-NodePackage }
+    'DotNet' { Publish-DotNetPackage }
+    'PowerShell' { Publish-PowerShellPackage }
+    'Python' { Publish-PythonPackages }
+    'Go' { Publish-GoPackages }
+}


### PR DESCRIPTION
## Summary

- add a single-tag GitHub Actions release workflow for Node, .NET, PowerShell, Python, and Go
- centralize package validation, testing, building, and publishing in a package-selectable PowerShell script
- publish both Python distributions together and create the path-prefixed tags required by the two Go modules
- add trusted-publisher configuration guidance and a manually dispatched dry-run mode that performs builds and checks without uploading packages or creating tags
- align package metadata and versions for the initial `v0.1.0` release

## Validation

- all package manifests pass the shared `v0.1.0` version preflight
- Node: 15 tests and public API check pass
- .NET: tests and package build pass
- PowerShell: 2 Pester tests and public API check pass
- Python: 6 tests, both public API checks, and both wheel/source builds pass
- Go: both module test suites and public API checks pass
- GitHub Actions YAML and PowerShell diagnostics report no errors