### PR TITLE
Use NuGet trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,17 +64,18 @@ jobs:
     - uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
-    - name: Log in to NuGet
+    - name: Build and test
+      shell: pwsh
+      run: ./scripts/Publish.ps1 -Package DotNet -Version $env:RELEASE_VERSION -SkipPublish
+    - name: Exchange OIDC token for temporary NuGet key
       if: env.DRY_RUN != 'true'
       id: nuget-login
       uses: NuGet/login@v1
       with:
-        user: ${{ vars.NUGET_USER }}
+        user: ${{ secrets.NUGET_USER }}
     - name: Publish
-      shell: pwsh
-      env:
-        NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
-      run: ./scripts/Publish.ps1 -Package DotNet -Version $env:RELEASE_VERSION -SkipPublish:([bool]::Parse($env:DRY_RUN))
+      if: env.DRY_RUN != 'true'
+      run: dotnet nuget push "artifacts/dotnet/*.nupkg" --api-key '${{ steps.nuget-login.outputs.NUGET_API_KEY }}' --source https://api.nuget.org/v3/index.json
 
   powershell:
     name: Publish PowerShell module

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -8,7 +8,7 @@ The workflow delegates package behavior to `scripts/Publish.ps1`. Select a relea
 ./scripts/Publish.ps1 -Package Node -Version 0.1.0 -SkipPublish
 ```
 
-For Python, the script builds both distributions into `artifacts/python`, and one workflow action uploads them together so trusted publishing can use GitHub's OIDC identity.
+For .NET and Python, the script builds release artifacts and the workflow performs the final upload using each registry's trusted-publishing identity. NuGet.org exchanges the GitHub OIDC token for a temporary API key immediately before `dotnet nuget push`; no long-lived NuGet key is stored in GitHub.
 
 To exercise the complete release pipeline without publishing, run the **Publish** workflow manually, enter the package version, and leave **dry_run** enabled. Dry-run jobs perform version checks, tests, API checks, and package builds, but skip registry authentication, uploads, and Go tag creation. Tag-triggered runs publish normally.
 
@@ -19,7 +19,7 @@ Create the `npm`, `nuget`, `pypi`, and `psgallery` environments in the GitHub re
 | Environment | Registry configuration |
 | --- | --- |
 | `npm` | On npmjs.com, configure a trusted publisher for package `@anthonycmartin/bicep-testing`, this repository, workflow `publish.yml`, and environment `npm`. No long-lived token is required. |
-| `nuget` | On nuget.org, configure a trusted publishing policy for package `AnthonyCMartin.BicepTesting`, this repository, workflow `publish.yml`, and environment `nuget`. Add the policy's nuget.org username as the GitHub environment variable `NUGET_USER`. |
+| `nuget` | On nuget.org, add a trusted publishing policy for the package owner with repository owner `anthony-c-martin`, repository `bicep-testing`, workflow `publish.yml`, and environment `nuget`. Add the policy owner's nuget.org profile name (not an email address) as the GitHub environment secret `NUGET_USER`. |
 | `pypi` | On PyPI, configure trusted publishers for `anthonycmartin-bicep-testing` and `bicep_rpc_client`, both using this repository, workflow `publish.yml`, and environment `pypi`. No long-lived token is required. |
 | `psgallery` | Add a PowerShell Gallery API key as the GitHub environment secret `PSGALLERY_API_KEY`. Scope and rotate the key according to the Gallery account policy. |
 

--- a/scripts/Publish.ps1
+++ b/scripts/Publish.ps1
@@ -101,14 +101,6 @@ function Publish-DotNetPackage {
     Assert-Version '.NET' $actualVersion
     Invoke-NativeCommand dotnet @('test', $solution, '--configuration', 'Release')
     Invoke-NativeCommand dotnet @('pack', $project, '--configuration', 'Release', "-p:PackageOutputPath=$output", '-p:ContinuousIntegrationBuild=true')
-    if (-not $SkipPublish) {
-        if ([string]::IsNullOrWhiteSpace($env:NUGET_API_KEY)) {
-            throw 'NUGET_API_KEY is required to publish the .NET package.'
-        }
-        Get-ChildItem $output -Filter '*.nupkg' | ForEach-Object {
-            Invoke-NativeCommand dotnet @('nuget', 'push', $_.FullName, '--api-key', $env:NUGET_API_KEY, '--source', 'https://api.nuget.org/v3/index.json')
-        }
-    }
 }
 
 function Publish-PowerShellPackage {


### PR DESCRIPTION
Switch the .NET release path to NuGet.org trusted publishing following the Microsoft Learn guidance.

- Build and test the NuGet package before authentication
- Exchange the GitHub OIDC token through `NuGet/login@v1` only for real releases
- Keep the temporary NuGet key and final push in the workflow instead of exposing credentials to `Publish.ps1`
- Document the owner-scoped trusted publishing policy and `NUGET_USER` environment secret
- Preserve dry runs without authentication or upload

Validation: `Publish.ps1 -Package DotNet -Version 0.1.0 -SkipPublish` (1 test passed; package created).