### PR TITLE
Rename published npm and Python packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Live tests compile a `.bicepparam` file, deploy it as an Azure Deployment Stack,
 
 ## Language support
 
-- [Node](docs/node.md) 22 or later: `@anthonycmartin/bicep-testing`, not yet available through npm
+- [Node](docs/node.md) 22 or later: `@anthony-c-martin/bicep-testing` on npm
 - [C#](docs/csharp.md) on .NET 10 or later: `AnthonyCMartin.BicepTesting`, not yet available through NuGet
 - [Go](docs/go.md) 1.24 or later: implemented, not yet released as a versioned Go module
 - [PowerShell](docs/powershell.md) 7.6 or later: `AnthonyCMartin.BicepTesting`, not yet available through the PowerShell Gallery
-- [Python](docs/python.md) 3.11 or later: `anthonycmartin-bicep-testing`, not yet available through PyPI
+- [Python](docs/python.md) 3.11 or later: `anthonycmartin-bicep-testing` on PyPI
 
-Lower-level Bicep CLI integrations are independently publishable as the Go `bicep-rpc-client` module and the Python `bicep_rpc_client` distribution, imported as `anthonycmartin.bicep_rpc_client`.
+Lower-level Bicep CLI integrations are independently publishable as the Go `bicep-rpc-client` module and the Python `anthonycmartin-bicep-rpc-client` distribution, imported as `anthonycmartin.bicep_rpc_client`.
 
 ## Samples
 

--- a/docs/node.md
+++ b/docs/node.md
@@ -1,6 +1,6 @@
 # Node
 
-The `@anthonycmartin/bicep-testing` package is the current reference implementation. It provides a Jest-based workflow for testing the predicted resources, outputs, and diagnostics of a Bicep deployment without deploying to Azure.
+The `@anthony-c-martin/bicep-testing` package is the current reference implementation. It provides a Jest-based workflow for testing the predicted resources, outputs, and diagnostics of a Bicep deployment without deploying to Azure.
 
 ## Requirements
 
@@ -9,17 +9,8 @@ The `@anthonycmartin/bicep-testing` package is the current reference implementat
 
 ## Installation
 
-The package has not yet been published to npm. Until it is released, build it from the repository root:
-
 ```sh
-npm --prefix packages/node install
-npm --prefix packages/node run build
-```
-
-Then install that package from the consuming project, replacing the path with the location of your checkout:
-
-```sh
-npm install --save-dev /path/to/bicep-testing/packages/node
+npm install --save-dev @anthony-c-martin/bicep-testing
 ```
 
 ## Usage
@@ -27,7 +18,7 @@ npm install --save-dev /path/to/bicep-testing/packages/node
 Create one session for the suite, capture the snapshot in setup, and dispose the Bicep process when the suite completes:
 
 ```ts
-import { BicepTestSession, SnapshotResult } from '@anthonycmartin/bicep-testing';
+import { BicepTestSession, SnapshotResult } from '@anthony-c-martin/bicep-testing';
 
 let session: BicepTestSession;
 let snapshot: SnapshotResult;

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -18,9 +18,9 @@ Create the `npm`, `nuget`, `pypi`, and `psgallery` environments in the GitHub re
 
 | Environment | Registry configuration |
 | --- | --- |
-| `npm` | On npmjs.com, configure a trusted publisher for package `@anthonycmartin/bicep-testing`, this repository, workflow `publish.yml`, and environment `npm`. No long-lived token is required. |
+| `npm` | On npmjs.com, configure a trusted publisher for package `@anthony-c-martin/bicep-testing`, this repository, workflow `publish.yml`, and environment `npm`. No long-lived token is required. |
 | `nuget` | On nuget.org, add a trusted publishing policy for the package owner with repository owner `anthony-c-martin`, repository `bicep-testing`, workflow `publish.yml`, and environment `nuget`. Add the policy owner's nuget.org profile name (not an email address) as the GitHub environment secret `NUGET_USER`. |
-| `pypi` | On PyPI, configure trusted publishers for `anthonycmartin-bicep-testing` and `bicep_rpc_client`, both using this repository, workflow `publish.yml`, and environment `pypi`. No long-lived token is required. |
+| `pypi` | On PyPI, configure trusted publishers for `anthonycmartin-bicep-testing` and `anthonycmartin-bicep-rpc-client`, both using this repository, workflow `publish.yml`, and environment `pypi`. No long-lived token is required. |
 | `psgallery` | Add a PowerShell Gallery API key as the GitHub environment secret `PSGALLERY_API_KEY`. Scope and rotate the key according to the Gallery account policy. |
 
 The Go proxy requires path-prefixed tags for modules in subdirectories. The workflow creates those compatibility tags automatically from the repository release tag; release authors still create only one tag.

--- a/docs/python.md
+++ b/docs/python.md
@@ -9,10 +9,8 @@ The Python package provides typed helpers for testing the predicted resources, o
 
 ## Installation
 
-Until `anthonycmartin-bicep-testing` is published to PyPI, install it from a local checkout:
-
 ```sh
-python -m pip install -e ./packages/python
+python -m pip install anthonycmartin-bicep-testing
 ```
 
 ## Usage
@@ -48,7 +46,7 @@ assert all(
 
 ## JSON-RPC client
 
-Most tests should use `BicepTestSession`. Lower-level integrations can install the standalone `bicep_rpc_client` distribution and import `BicepClientFactory`, `BicepClientConfiguration`, and typed request models from `anthonycmartin.bicep_rpc_client`. The factory can download a pinned Bicep CLI or connect through an existing CLI path. The returned client owns the process until `close` is called and supports context-manager cleanup.
+Most tests should use `BicepTestSession`. Lower-level integrations can install the standalone `anthonycmartin-bicep-rpc-client` distribution and import `BicepClientFactory`, `BicepClientConfiguration`, and typed request models from `anthonycmartin.bicep_rpc_client`. The factory can download a pinned Bicep CLI or connect through an existing CLI path. The returned client owns the process until `close` is called and supports context-manager cleanup.
 
 ```python
 from anthonycmartin.bicep_rpc_client import (

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,4 +1,4 @@
-# @anthonycmartin/bicep-testing
+# @anthony-c-martin/bicep-testing
 
 The independent, non-official Node library for asserting on Bicep templates without deploying to Azure.
 

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@anthonycmartin/bicep-testing",
+  "name": "@anthony-c-martin/bicep-testing",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@anthonycmartin/bicep-testing",
+      "name": "@anthony-c-martin/bicep-testing",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@anthonycmartin/bicep-testing",
+  "name": "@anthony-c-martin/bicep-testing",
   "version": "0.1.0",
   "description": "Test library for interacting with the Bicep CLI.",
   "main": "dist/index.js",

--- a/packages/python/bicep_rpc_client/README.md
+++ b/packages/python/bicep_rpc_client/README.md
@@ -1,6 +1,6 @@
-# bicep_rpc_client
+# Bicep RPC Client for Python
 
-An independent Python client for the Bicep CLI JSON-RPC API. The distribution is named `bicep_rpc_client` and its public API is namespaced under `anthonycmartin.bicep_rpc_client`.
+An independent Python client for the Bicep CLI JSON-RPC API. Install the `anthonycmartin-bicep-rpc-client` distribution and import its public API from `anthonycmartin.bicep_rpc_client`.
 
 ```python
 from anthonycmartin.bicep_rpc_client import (

--- a/packages/python/bicep_rpc_client/pyproject.toml
+++ b/packages/python/bicep_rpc_client/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "bicep_rpc_client"
+name = "anthonycmartin-bicep-rpc-client"
 version = "0.1.0"
 description = "Interact with the Bicep CLI through its JSON-RPC API."
 readme = "README.md"

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.11"
 license = "MIT"
 authors = [{ name = "Anthony Martin" }]
 dependencies = [
-	"bicep_rpc_client>=0.1.0",
+	"anthonycmartin-bicep-rpc-client>=0.1.0",
 	"azure-mgmt-resource-deploymentstacks==1.0.0",
 ]
 

--- a/samples/node/deployment.test.js
+++ b/samples/node/deployment.test.js
@@ -1,6 +1,6 @@
 const path = require('node:path');
 const { DefaultAzureCredential } = require('@azure/identity');
-const { BicepTestSession } = require('@anthonycmartin/bicep-testing');
+const { BicepTestSession } = require('@anthony-c-martin/bicep-testing');
 
 const subscriptionId = process.env.AZURE_SUBSCRIPTION_ID;
 const resourceGroup = process.env.AZURE_RESOURCE_GROUP;

--- a/samples/node/package.json
+++ b/samples/node/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@azure/identity": "^4.13.0",
-    "@anthonycmartin/bicep-testing": "file:../../packages/node"
+    "@anthony-c-martin/bicep-testing": "file:../../packages/node"
   },
   "devDependencies": {
     "jest": "30.4.2"

--- a/samples/node/snapshot.test.js
+++ b/samples/node/snapshot.test.js
@@ -1,5 +1,5 @@
 const path = require('node:path');
-const { BicepTestSession } = require('@anthonycmartin/bicep-testing');
+const { BicepTestSession } = require('@anthony-c-martin/bicep-testing');
 
 const sampleDescribe = process.env.BICEP_TEST_VALIDATE_ONLY === '1' ? describe.skip : describe;
 


### PR DESCRIPTION
## Summary

- rename the npm package from `@anthonycmartin/bicep-testing` to the published `@anthony-c-martin/bicep-testing` scope
- rename the standalone Python distribution from `bicep_rpc_client` to `anthonycmartin-bicep-rpc-client` while preserving the `anthonycmartin.bicep_rpc_client` import namespace
- update the high-level Python package dependency, Node samples, installation docs, and trusted-publisher setup guidance
- replace pre-publication instructions with the live npm and PyPI install commands

The initial `0.1.0` releases are now public on npm and PyPI, and trusted publishing has been configured for future releases.

## Validation

- Node: 15 tests pass and the public API baseline is current
- Node sample: 1 test passes and 1 deployment test is intentionally skipped
- Python: 6 tests pass and both public API baselines are current
- both Python wheels and source distributions build and pass `twine check`
- a clean virtual environment installs `anthonycmartin-bicep-testing==0.1.0`, resolves `anthonycmartin-bicep-rpc-client==0.1.0`, and imports both packages
- npm and both PyPI `0.1.0` releases are publicly visible