### PR TITLE
Update samples to use published packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Live tests compile a `.bicepparam` file, deploy it as an Azure Deployment Stack,
 
 ## Language support
 
-- [Node](docs/node.md) 22 or later: `@anthony-c-martin/bicep-testing` on npm
-- [C#](docs/csharp.md) on .NET 10 or later: `AnthonyCMartin.BicepTesting`, not yet available through NuGet
-- [Go](docs/go.md) 1.24 or later: implemented, not yet released as a versioned Go module
-- [PowerShell](docs/powershell.md) 7.6 or later: `AnthonyCMartin.BicepTesting`, not yet available through the PowerShell Gallery
-- [Python](docs/python.md) 3.11 or later: `anthonycmartin-bicep-testing` on PyPI
+- [Node](docs/node.md) 22 or later: `@anthony-c-martin/bicep-testing` 0.1.0 on npm
+- [C#](docs/csharp.md) on .NET 10 or later: `AnthonyCMartin.BicepTesting` 0.1.0 on NuGet
+- [Go](docs/go.md) 1.24 or later: `github.com/anthony-c-martin/bicep-testing/packages/go` v0.1.0
+- [PowerShell](docs/powershell.md) 7.6 or later: `AnthonyCMartin.BicepTesting` 0.1.0 on the PowerShell Gallery
+- [Python](docs/python.md) 3.11 or later: `anthonycmartin-bicep-testing` 0.1.0 on PyPI
 
-Lower-level Bicep CLI integrations are independently publishable as the Go `bicep-rpc-client` module and the Python `anthonycmartin-bicep-rpc-client` distribution, imported as `anthonycmartin.bicep_rpc_client`.
+Lower-level Bicep CLI integrations are published as the Go `bicep-rpc-client` module at v0.1.0 and the Python `anthonycmartin-bicep-rpc-client` distribution at 0.1.0, imported as `anthonycmartin.bicep_rpc_client`.
 
 ## Samples
 

--- a/docs/csharp.md
+++ b/docs/csharp.md
@@ -9,7 +9,9 @@ The C# library provides helpers for testing the predicted resources, outputs, an
 
 ## Installation
 
-The `AnthonyCMartin.BicepTesting` package has not yet been published to NuGet. Until it is released, reference `packages/dotnet/src/BicepTest/BicepTest.csproj` from a local checkout.
+```sh
+dotnet add package AnthonyCMartin.BicepTesting --version 0.1.0
+```
 
 ## Usage
 

--- a/docs/go.md
+++ b/docs/go.md
@@ -9,10 +9,8 @@ The Go package provides helpers for testing the predicted resources, outputs, an
 
 ## Installation
 
-Until a versioned module is released, reference the repository source from a local checkout. After release, install it with:
-
 ```sh
-go get github.com/anthony-c-martin/bicep-testing/packages/go
+go get github.com/anthony-c-martin/bicep-testing/packages/go@v0.1.0
 ```
 
 ## Usage
@@ -64,6 +62,10 @@ func TestStorageAccountsDisablePublicAccess(t *testing.T) {
 ## JSON-RPC client
 
 Lower-level integrations can use the independently versioned `bicep-rpc-client` module:
+
+```sh
+go get github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client@v0.1.0
+```
 
 ```go
 import biceprpcclient "github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client"

--- a/docs/node.md
+++ b/docs/node.md
@@ -10,7 +10,7 @@ The `@anthony-c-martin/bicep-testing` package is the current reference implement
 ## Installation
 
 ```sh
-npm install --save-dev @anthony-c-martin/bicep-testing
+npm install --save-dev @anthony-c-martin/bicep-testing@0.1.0
 ```
 
 ## Usage

--- a/docs/powershell.md
+++ b/docs/powershell.md
@@ -5,16 +5,13 @@ The PowerShell module provides commands for testing the predicted resources, out
 ## Requirements
 
 - PowerShell 7.6 or later
-- .NET 10 SDK or later when building from source
 - A `.bicepparam` entry point for the Bicep deployment under test
 
-## Build
-
-The `AnthonyCMartin.BicepTesting` module has not yet been published to the PowerShell Gallery. Build its runtime payload from a local checkout:
+## Installation
 
 ```powershell
-./packages/powershell/build.ps1
-Import-Module ./packages/powershell/AnthonyCMartin.BicepTesting/AnthonyCMartin.BicepTesting.psd1
+Install-PSResource AnthonyCMartin.BicepTesting -Version 0.1.0 -Repository PSGallery
+Import-Module AnthonyCMartin.BicepTesting -RequiredVersion 0.1.0
 ```
 
 ## Usage

--- a/docs/python.md
+++ b/docs/python.md
@@ -10,7 +10,7 @@ The Python package provides typed helpers for testing the predicted resources, o
 ## Installation
 
 ```sh
-python -m pip install anthonycmartin-bicep-testing
+python -m pip install anthonycmartin-bicep-testing==0.1.0
 ```
 
 ## Usage
@@ -46,7 +46,7 @@ assert all(
 
 ## JSON-RPC client
 
-Most tests should use `BicepTestSession`. Lower-level integrations can install the standalone `anthonycmartin-bicep-rpc-client` distribution and import `BicepClientFactory`, `BicepClientConfiguration`, and typed request models from `anthonycmartin.bicep_rpc_client`. The factory can download a pinned Bicep CLI or connect through an existing CLI path. The returned client owns the process until `close` is called and supports context-manager cleanup.
+Most tests should use `BicepTestSession`. Lower-level integrations can install the standalone distribution with `python -m pip install anthonycmartin-bicep-rpc-client==0.1.0` and import `BicepClientFactory`, `BicepClientConfiguration`, and typed request models from `anthonycmartin.bicep_rpc_client`. The factory can download a pinned Bicep CLI or connect through an existing CLI path. The returned client owns the process until `close` is called and supports context-manager cleanup.
 
 ```python
 from anthonycmartin.bicep_rpc_client import (

--- a/packages/go/bicep-rpc-client/README.md
+++ b/packages/go/bicep-rpc-client/README.md
@@ -2,6 +2,10 @@
 
 An independent Go client for the Bicep CLI JSON-RPC API.
 
+```sh
+go get github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client@v0.1.0
+```
+
 ```go
 package main
 

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```sh
-python -m pip install anthonycmartin-bicep-testing
+python -m pip install anthonycmartin-bicep-testing==0.1.0
 ```
 
 See the [Python documentation](https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/python.md) for usage and lifecycle examples.

--- a/packages/python/bicep_rpc_client/README.md
+++ b/packages/python/bicep_rpc_client/README.md
@@ -2,6 +2,10 @@
 
 An independent Python client for the Bicep CLI JSON-RPC API. Install the `anthonycmartin-bicep-rpc-client` distribution and import its public API from `anthonycmartin.bicep_rpc_client`.
 
+```sh
+python -m pip install anthonycmartin-bicep-rpc-client==0.1.0
+```
+
 ```python
 from anthonycmartin.bicep_rpc_client import (
     BicepClientConfiguration,

--- a/samples/README.md
+++ b/samples/README.md
@@ -25,6 +25,6 @@ Validate every sample from the repository root:
 ./scripts/ValidateSamples.ps1
 ```
 
-The validator restores the local libraries and dependencies, then compiles, parses, or collects every sample test. It does not execute snapshot or live deployment tests, so standard CI remains credential-free and cannot create Azure resources.
+The validator restores the published version 0.1.0 libraries and dependencies, then compiles, parses, or collects every sample test. It does not execute snapshot or live deployment tests, so standard CI remains credential-free and cannot create Azure resources.
 
 To run a language's tests, use its native test command after setting the live deployment environment variables. Without those variables, only the credential-free snapshot tests run and the deployment test is skipped.

--- a/samples/dotnet/BicepTest.Sample.csproj
+++ b/samples/dotnet/BicepTest.Sample.csproj
@@ -9,11 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AnthonyCMartin.BicepTesting" Version="0.1.0" />
     <PackageReference Include="MSTest" Version="4.3.3" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="../../packages/dotnet/src/BicepTest/BicepTest.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/dotnet/DeploymentTests.cs
+++ b/samples/dotnet/DeploymentTests.cs
@@ -1,8 +1,9 @@
+using AnthonyCMartin.BicepTesting;
 using Azure.Identity;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Text.Json;
 
-namespace AnthonyCMartin.BicepTesting.Sample;
+namespace Samples;
 
 [TestClass]
 public sealed class DeploymentTests
@@ -23,7 +24,7 @@ public sealed class DeploymentTests
         await using var session = await AnthonyCMartin.BicepTesting.BicepTestSession.CreateAsync("0.43.1", TestContext.CancellationToken);
         await using var deployment = await session.DeployAsync(
             new DefaultAzureCredential(),
-            new AnthonyCMartin.BicepTesting.DeployOptions
+            new DeployOptions
             {
                 FilePath = parametersPath,
                 SubscriptionId = subscriptionId,

--- a/samples/dotnet/SnapshotTests.cs
+++ b/samples/dotnet/SnapshotTests.cs
@@ -1,6 +1,7 @@
+using AnthonyCMartin.BicepTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace AnthonyCMartin.BicepTesting.Sample;
+namespace Samples;
 
 [TestClass]
 public sealed class SnapshotTests
@@ -14,7 +15,7 @@ public sealed class SnapshotTests
         var parametersPath = Path.GetFullPath(
             Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "infra", "main.bicepparam"));
 
-        await using var session = await AnthonyCMartin.BicepTesting.BicepTestSession.CreateAsync("0.43.1", TestContext.CancellationToken);
+        await using var session = await BicepTestSession.CreateAsync("0.43.1", TestContext.CancellationToken);
         var snapshot = await session.SnapshotAsync(
             parametersPath,
             "00000000-0000-0000-0000-000000000000",

--- a/samples/go/go.mod
+++ b/samples/go/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1
-	github.com/anthony-c-martin/bicep-testing/packages/go v0.0.0
+	github.com/anthony-c-martin/bicep-testing/packages/go v0.1.0
 )
 
 require (
@@ -23,7 +23,3 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 )
-
-replace github.com/anthony-c-martin/bicep-testing/packages/go => ../../packages/go
-
-replace github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client => ../../packages/go/bicep-rpc-client

--- a/samples/go/go.sum
+++ b/samples/go/go.sum
@@ -14,6 +14,10 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 h1:oygO0locgZJ
 github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/anthony-c-martin/bicep-testing/packages/go v0.1.0 h1:14KxxFK922GVQh2KZlc06wnzvi0UZD5yHRDnlTjajL0=
+github.com/anthony-c-martin/bicep-testing/packages/go v0.1.0/go.mod h1:3SG6i+1DBceftRjh2uXhCCcLxLBYbvMhUY1ovgu7P3Y=
+github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client v0.1.0 h1:LDERq3zL6wMFxA7THjhPg8fAVWnyDP4MuP6IVzAzv5Y=
+github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client v0.1.0/go.mod h1:UiQAgrrYy21PC4O2+LXEuqoRUTglNz3epmblaVtoUFg=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/samples/node/package.json
+++ b/samples/node/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@azure/identity": "^4.13.0",
-    "@anthony-c-martin/bicep-testing": "file:../../packages/node"
+    "@anthony-c-martin/bicep-testing": "0.1.0"
   },
   "devDependencies": {
     "jest": "30.4.2"

--- a/samples/powershell/BicepTest.Deployment.Sample.Tests.ps1
+++ b/samples/powershell/BicepTest.Deployment.Sample.Tests.ps1
@@ -1,7 +1,6 @@
 BeforeAll {
-    $modulePath = Join-Path $PSScriptRoot '../../packages/powershell/AnthonyCMartin.BicepTesting/AnthonyCMartin.BicepTesting.psd1'
     $parametersPath = Join-Path $PSScriptRoot '../infra/main.bicepparam'
-    Import-Module $modulePath -Force
+    Import-Module AnthonyCMartin.BicepTesting -RequiredVersion 0.1.0 -Force
 }
 
 Describe 'Bicep infrastructure deployment' -Skip:(

--- a/samples/powershell/BicepTest.Sample.Tests.ps1
+++ b/samples/powershell/BicepTest.Sample.Tests.ps1
@@ -1,7 +1,6 @@
 BeforeAll {
-    $modulePath = Join-Path $PSScriptRoot '../../packages/powershell/AnthonyCMartin.BicepTesting/AnthonyCMartin.BicepTesting.psd1'
     $parametersPath = Join-Path $PSScriptRoot '../infra/main.bicepparam'
-    Import-Module $modulePath -Force
+    Import-Module AnthonyCMartin.BicepTesting -RequiredVersion 0.1.0 -Force
 
     $session = New-BicepTestSession -BicepVersion '0.43.1'
     $snapshot = $session | Get-BicepSnapshot `

--- a/samples/python/requirements.txt
+++ b/samples/python/requirements.txt
@@ -1,4 +1,4 @@
--e ../../packages/python/bicep_rpc_client
--e ../../packages/python
+anthonycmartin-bicep-rpc-client==0.1.0
+anthonycmartin-bicep-testing==0.1.0
 azure-identity>=1.25.3
 pytest>=9.1.1

--- a/scripts/ValidateSamples.ps1
+++ b/scripts/ValidateSamples.ps1
@@ -20,9 +20,7 @@ function Invoke-NativeCommand {
 
 Push-Location $repositoryRoot
 try {
-    Write-Host 'Building the Node library and sample...'
-    Invoke-NativeCommand { npm ci --prefix packages/node --legacy-peer-deps } 'Node dependency restore'
-    Invoke-NativeCommand { npm run build --prefix packages/node } 'Node library build'
+    Write-Host 'Restoring and compiling the Node sample...'
     Invoke-NativeCommand { npm install --prefix samples/node --ignore-scripts --no-package-lock } 'Node sample dependency restore'
     Invoke-NativeCommand { $env:BICEP_TEST_VALIDATE_ONLY = '1'; npm test --prefix samples/node } 'Node sample compilation'
     Remove-Item Env:BICEP_TEST_VALIDATE_ONLY -ErrorAction SilentlyContinue
@@ -39,8 +37,8 @@ try {
         Pop-Location
     }
 
-    Write-Host 'Parsing the PowerShell sample tests...'
-    Invoke-NativeCommand { pwsh -NoProfile -File packages/powershell/build.ps1 } 'PowerShell module build'
+    Write-Host 'Installing and parsing the PowerShell sample tests...'
+    Install-PSResource AnthonyCMartin.BicepTesting -Version 0.1.0 -Repository PSGallery -Scope CurrentUser -TrustRepository -Reinstall -Quiet
     Invoke-NativeCommand {
         pwsh -NoProfile -Command '$errors = @(); Get-ChildItem ./samples/powershell -Filter *.ps1 | ForEach-Object { [void][Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$null, [ref]$errors) }; if ($errors) { $errors | Out-String | Write-Error; exit 1 }'
     } 'PowerShell sample parsing'


### PR DESCRIPTION
## Summary

- update installation docs to reference the published `0.1.0` packages for all five language libraries and both standalone RPC clients
- switch consumer samples from local source references to exact npm, NuGet, Go, PowerShell Gallery, and PyPI versions
- update sample validation to restore published artifacts, including PowerShell installation through PSResourceGet

## Validation

- `./scripts/ValidateSamples.ps1`
- all Node, C#, Go, PowerShell, and Python samples compiled, parsed, or collected successfully