### PR TITLE
Add package READMEs and bump version to 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Live tests compile a `.bicepparam` file, deploy it as an Azure Deployment Stack,
 
 ## Language support
 
-- [Node](docs/node.md) 22 or later: `@anthony-c-martin/bicep-testing` 0.1.1 on npm
-- [C#](docs/csharp.md) on .NET 10 or later: `AnthonyCMartin.BicepTesting` 0.1.1 on NuGet
-- [Go](docs/go.md) 1.24 or later: `github.com/anthony-c-martin/bicep-testing/packages/go` v0.1.1
-- [PowerShell](docs/powershell.md) 7.6 or later: `AnthonyCMartin.BicepTesting` 0.1.1 on the PowerShell Gallery
-- [Python](docs/python.md) 3.11 or later: `anthonycmartin-bicep-testing` 0.1.1 on PyPI
+- [Node](docs/node.md) 22 or later: `@anthony-c-martin/bicep-testing` 0.1.2 on npm
+- [C#](docs/csharp.md) on .NET 10 or later: `AnthonyCMartin.BicepTesting` 0.1.2 on NuGet
+- [Go](docs/go.md) 1.24 or later: `github.com/anthony-c-martin/bicep-testing/packages/go` v0.1.2
+- [PowerShell](docs/powershell.md) 7.6 or later: `AnthonyCMartin.BicepTesting` 0.1.2 on the PowerShell Gallery
+- [Python](docs/python.md) 3.11 or later: `anthonycmartin-bicep-testing` 0.1.2 on PyPI
 
-Lower-level Bicep CLI integrations are published as the Go `bicep-rpc-client` module at v0.1.1 and the Python `anthonycmartin-bicep-rpc-client` distribution at 0.1.1, imported as `anthonycmartin.bicep_rpc_client`.
+Lower-level Bicep CLI integrations are published as the Go `bicep-rpc-client` module at v0.1.2 and the Python `anthonycmartin-bicep-rpc-client` distribution at 0.1.2, imported as `anthonycmartin.bicep_rpc_client`.
 
 ## Samples
 

--- a/docs/csharp.md
+++ b/docs/csharp.md
@@ -10,7 +10,7 @@ The C# library provides helpers for testing the predicted resources, outputs, an
 ## Installation
 
 ```sh
-dotnet add package AnthonyCMartin.BicepTesting --version 0.1.1
+dotnet add package AnthonyCMartin.BicepTesting --version 0.1.2
 ```
 
 ## Usage

--- a/docs/go.md
+++ b/docs/go.md
@@ -10,7 +10,7 @@ The Go package provides helpers for testing the predicted resources, outputs, an
 ## Installation
 
 ```sh
-go get github.com/anthony-c-martin/bicep-testing/packages/go@v0.1.1
+go get github.com/anthony-c-martin/bicep-testing/packages/go@v0.1.2
 ```
 
 ## Usage
@@ -64,7 +64,7 @@ func TestStorageAccountsDisablePublicAccess(t *testing.T) {
 Lower-level integrations can use the independently versioned `bicep-rpc-client` module:
 
 ```sh
-go get github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client@v0.1.1
+go get github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client@v0.1.2
 ```
 
 ```go

--- a/docs/node.md
+++ b/docs/node.md
@@ -10,7 +10,7 @@ The `@anthony-c-martin/bicep-testing` package is the current reference implement
 ## Installation
 
 ```sh
-npm install --save-dev @anthony-c-martin/bicep-testing@0.1.1
+npm install --save-dev @anthony-c-martin/bicep-testing@0.1.2
 ```
 
 ## Usage

--- a/docs/powershell.md
+++ b/docs/powershell.md
@@ -10,8 +10,8 @@ The PowerShell module provides commands for testing the predicted resources, out
 ## Installation
 
 ```powershell
-Install-PSResource AnthonyCMartin.BicepTesting -Version 0.1.1 -Repository PSGallery
-Import-Module AnthonyCMartin.BicepTesting -RequiredVersion 0.1.1
+Install-PSResource AnthonyCMartin.BicepTesting -Version 0.1.2 -Repository PSGallery
+Import-Module AnthonyCMartin.BicepTesting -RequiredVersion 0.1.2
 ```
 
 ## Usage

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,11 +1,11 @@
 # Publishing packages
 
-All packages are released together from one repository tag. Pushing a semantic-version tag such as `v0.1.1` starts `.github/workflows/publish.yml`, which verifies the tag against every package manifest, runs the package tests and public API checks, builds the artifacts, and publishes through protected GitHub environments.
+All packages are released together from one repository tag. Pushing a semantic-version tag such as `v0.1.2` starts `.github/workflows/publish.yml`, which verifies the tag against every package manifest, runs the package tests and public API checks, builds the artifacts, and publishes through protected GitHub environments.
 
 The workflow delegates package behavior to `scripts/Publish.ps1`. Select a release unit with `-Package Validate`, `Node`, `DotNet`, `PowerShell`, `Python`, or `Go`, and pass the shared version with `-Version`. The `Python` selector builds both Python distributions together. Use `-SkipPublish` to run validation, tests, and packaging without uploading or creating tags:
 
 ```powershell
-./scripts/Publish.ps1 -Package Node -Version 0.1.1 -SkipPublish
+./scripts/Publish.ps1 -Package Node -Version 0.1.2 -SkipPublish
 ```
 
 For .NET and Python, the script builds release artifacts and the workflow performs the final upload using each registry's trusted-publishing identity. NuGet.org exchanges the GitHub OIDC token for a temporary API key immediately before `dotnet nuget push`; no long-lived NuGet key is stored in GitHub.
@@ -48,8 +48,8 @@ For example:
 ```sh
 git switch main
 git pull --ff-only
-git tag -a v0.1.1 -m "Release v0.1.1"
-git push origin v0.1.1
+git tag -a v0.1.2 -m "Release v0.1.2"
+git push origin v0.1.2
 ```
 
 Registry versions are immutable. If publishing succeeds but a later verification step fails, fix the issue and release a new patch version rather than reusing the tag.

--- a/docs/python.md
+++ b/docs/python.md
@@ -10,7 +10,7 @@ The Python package provides typed helpers for testing the predicted resources, o
 ## Installation
 
 ```sh
-python -m pip install anthonycmartin-bicep-testing==0.1.1
+python -m pip install anthonycmartin-bicep-testing==0.1.2
 ```
 
 ## Usage
@@ -46,7 +46,7 @@ assert all(
 
 ## JSON-RPC client
 
-Most tests should use `BicepTestSession`. Lower-level integrations can install the standalone distribution with `python -m pip install anthonycmartin-bicep-rpc-client==0.1.1` and import `BicepClientFactory`, `BicepClientConfiguration`, and typed request models from `anthonycmartin.bicep_rpc_client`. The factory can download a pinned Bicep CLI or connect through an existing CLI path. The returned client owns the process until `close` is called and supports context-manager cleanup.
+Most tests should use `BicepTestSession`. Lower-level integrations can install the standalone distribution with `python -m pip install anthonycmartin-bicep-rpc-client==0.1.2` and import `BicepClientFactory`, `BicepClientConfiguration`, and typed request models from `anthonycmartin.bicep_rpc_client`. The factory can download a pinned Bicep CLI or connect through an existing CLI path. The returned client owns the process until `close` is called and supports context-manager cleanup.
 
 ```python
 from anthonycmartin.bicep_rpc_client import (

--- a/packages/dotnet/README.md
+++ b/packages/dotnet/README.md
@@ -1,0 +1,87 @@
+# AnthonyCMartin.BicepTesting
+
+Test the resources, outputs, and diagnostics produced by a Bicep deployment without deploying to Azure. The package can also run opt-in integration tests against a real Azure Deployment Stack when an assertion requires live resources.
+
+This is an independent, non-official project.
+
+## Requirements
+
+- .NET 10 or later
+- A `.bicepparam` entry point for the deployment under test
+
+## Installation
+
+```sh
+dotnet add package AnthonyCMartin.BicepTesting --version 0.1.2
+```
+
+## Snapshot testing
+
+Create and asynchronously dispose a session within the test lifetime:
+
+```csharp
+using AnthonyCMartin.BicepTesting;
+
+await using var session = await BicepTestSession.CreateAsync("0.43.1");
+var snapshot = await session.SnapshotAsync(
+    "infra/main.bicepparam",
+    tenantId: "00000000-0000-0000-0000-000000000000",
+    subscriptionId: "00000000-0000-0000-0000-000000000000",
+    resourceGroup: "example-rg",
+    location: "eastus",
+    deploymentName: "example-deployment");
+
+Assert.IsEmpty(snapshot.Diagnostics);
+var storageAccounts = snapshot.PredictedResources.Where(
+    resource => resource.Type == "Microsoft.Storage/storageAccounts");
+Assert.IsTrue(storageAccounts.Any());
+Assert.IsTrue(storageAccounts.All(resource =>
+    resource.Properties.GetProperty("allowBlobPublicAccess").GetBoolean() is false));
+```
+
+`BicepTestSession.CreateAsync()` downloads the requested Bicep CLI version and reuses it on later runs. The session owns a Bicep process, so use `await using` or call `DisposeAsync()` after the tests finish. Pass the test framework's `CancellationToken` to session creation and operations when available.
+
+Snapshot tests run locally. The subscription, tenant, resource group, location, and deployment values provide evaluation context only; they do not need to exist, and no Azure credentials are required.
+
+## Snapshot results
+
+`SnapshotAsync()` returns:
+
+- `PredictedResources`: resources and resolved properties predicted for the deployment
+- `Outputs`: resolved deployment outputs
+- `Diagnostics`: Bicep compilation warnings and errors
+
+## Live deployment testing
+
+Use `DeployAsync()` only when a test must inspect a real Azure resource or service response:
+
+```csharp
+using Azure.Identity;
+using System.Text.Json;
+
+await using var deployment = await session.DeployAsync(
+    new DefaultAzureCredential(),
+    new DeployOptions
+    {
+        FilePath = "infra/main.bicepparam",
+        SubscriptionId = subscriptionId,
+        ResourceGroup = resourceGroup,
+        StackName = $"bicep-test-{Guid.NewGuid():N}",
+        ParameterOverrides = new Dictionary<string, JsonElement>
+        {
+            ["env"] = JsonSerializer.SerializeToElement("integration"),
+        },
+    });
+
+Assert.IsTrue(deployment.Resources.Any(
+    resource => resource.Type == "Microsoft.Storage/storageAccounts"));
+```
+
+Live tests require Azure credentials, an existing resource group, and permission to create and delete Deployment Stacks and their managed resources. Asynchronous disposal is idempotent and deletes the stack and all resources it manages. Use a unique stack name and keep the result in an `await using` scope.
+
+## More information
+
+- [Runnable MSTest snapshot and deployment samples](https://github.com/anthony-c-martin/bicep-testing/tree/main/samples/dotnet)
+- [Complete C# guide](https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/csharp.md)
+- [Exported API](https://github.com/anthony-c-martin/bicep-testing/blob/main/api/dotnet/PublicAPI.Unshipped.txt)
+- [Project repository](https://github.com/anthony-c-martin/bicep-testing)

--- a/packages/dotnet/src/BicepTest/BicepTest.csproj
+++ b/packages/dotnet/src/BicepTest/BicepTest.csproj
@@ -5,11 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>AnthonyCMartin.BicepTesting</PackageId>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <AssemblyName>AnthonyCMartin.BicepTesting</AssemblyName>
     <RootNamespace>AnthonyCMartin.BicepTesting</RootNamespace>
     <Description>Test library for interacting with the Bicep CLI.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/anthony-c-martin/bicep-testing</RepositoryUrl>
     <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017</WarningsAsErrors>
   </PropertyGroup>
@@ -26,6 +27,7 @@
   <ItemGroup>
     <AdditionalFiles Include="../../../../api/dotnet/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="../../../../api/dotnet/PublicAPI.Unshipped.txt" />
+    <None Include="../../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/packages/go/README.md
+++ b/packages/go/README.md
@@ -1,0 +1,109 @@
+# Bicep Testing for Go
+
+Test the resources, outputs, and diagnostics produced by a Bicep deployment without deploying to Azure. The package can also run opt-in integration tests against a real Azure Deployment Stack when an assertion requires live resources.
+
+This is an independent, non-official project.
+
+## Requirements
+
+- Go 1.24 or later
+- A `.bicepparam` entry point for the deployment under test
+
+## Installation
+
+```sh
+go get github.com/anthony-c-martin/bicep-testing/packages/go@v0.1.2
+```
+
+## Snapshot testing
+
+Create a session for the test and register cleanup immediately:
+
+```go
+package infra_test
+
+import (
+	"context"
+	"testing"
+
+	biceptesting "github.com/anthony-c-martin/bicep-testing/packages/go"
+)
+
+func TestStorageAccountsDisablePublicAccess(t *testing.T) {
+	ctx := context.Background()
+	session, err := biceptesting.NewSession(ctx, "0.43.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := session.Close(); err != nil {
+			t.Errorf("close session: %v", err)
+		}
+	})
+
+	snapshot, err := session.Snapshot(ctx, "infra/main.bicepparam", biceptesting.SnapshotMetadata{
+		TenantID:       "00000000-0000-0000-0000-000000000000",
+		SubscriptionID: "00000000-0000-0000-0000-000000000000",
+		ResourceGroup:  "example-rg",
+		Location:       "eastus",
+		DeploymentName: "example-deployment",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(snapshot.Diagnostics) != 0 {
+		t.Fatalf("got %d diagnostics, want none", len(snapshot.Diagnostics))
+	}
+	for _, resource := range snapshot.PredictedResources {
+		if resource.Type == "Microsoft.Storage/storageAccounts" &&
+			resource.Properties["allowBlobPublicAccess"] != false {
+			t.Errorf("storage account %q allows public blob access", resource.Name)
+		}
+	}
+}
+```
+
+`NewSession()` downloads the requested Bicep CLI version into `~/.bicep/bin` and reuses it on later runs. The session owns a Bicep process, so always call `Close()`. Every operation accepts a `context.Context` for cancellation and deadlines.
+
+Snapshot tests run locally. The subscription, tenant, resource group, location, and deployment values provide evaluation context only; they do not need to exist, and no Azure credentials are required.
+
+## Snapshot results
+
+`Snapshot()` returns:
+
+- `PredictedResources`: resources and resolved properties predicted for the deployment
+- `Outputs`: resolved deployment outputs
+- `Diagnostics`: Bicep compilation warnings and errors
+
+## Live deployment testing
+
+Use `Deploy()` only when a test must inspect a real Azure resource or service response:
+
+```go
+deployment, err := session.Deploy(ctx, credential, biceptesting.DeployOptions{
+	FilePath:       "infra/main.bicepparam",
+	SubscriptionID: subscriptionID,
+	ResourceGroup:  resourceGroup,
+	StackName:      fmt.Sprintf("bicep-test-%d", time.Now().UnixNano()),
+})
+if err != nil {
+	t.Fatal(err)
+}
+t.Cleanup(func() {
+	if err := deployment.Teardown(context.Background()); err != nil {
+		t.Errorf("tear down deployment: %v", err)
+	}
+})
+```
+
+Live tests require an `azcore.TokenCredential`, an existing resource group, and permission to create and delete Deployment Stacks and their managed resources. `Teardown()` is idempotent and deletes the stack and all resources it manages. Use a unique stack name and register teardown immediately after deployment.
+
+Lower-level Bicep integrations can use the separately versioned [bicep-rpc-client module](https://github.com/anthony-c-martin/bicep-testing/tree/main/packages/go/bicep-rpc-client).
+
+## More information
+
+- [Runnable Go snapshot and deployment samples](https://github.com/anthony-c-martin/bicep-testing/tree/main/samples/go)
+- [Complete Go guide](https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/go.md)
+- [Exported API](https://github.com/anthony-c-martin/bicep-testing/blob/main/api/go/biceptesting.txt)
+- [Project repository](https://github.com/anthony-c-martin/bicep-testing)

--- a/packages/go/bicep-rpc-client/README.md
+++ b/packages/go/bicep-rpc-client/README.md
@@ -7,7 +7,7 @@ An independent Go client for programmatically interacting with the [Bicep CLI](h
 ### Install the module
 
 ```sh
-go get github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client@v0.1.1
+go get github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client@v0.1.2
 ```
 
 ### Initialize the client

--- a/packages/go/go.mod
+++ b/packages/go/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeploymentstacks v1.0.1
-	github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client v0.1.1
+	github.com/anthony-c-martin/bicep-testing/packages/go/bicep-rpc-client v0.1.2
 )
 
 require (

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,5 +1,195 @@
 # @anthony-c-martin/bicep-testing
 
-The independent, non-official Node library for asserting on Bicep templates without deploying to Azure.
+Test the resources, outputs, and diagnostics produced by a Bicep deployment without deploying to Azure. The package can also run opt-in integration tests against a real Azure Deployment Stack when an assertion requires live resources.
 
-See the [repository README](https://github.com/anthony-c-martin/bicep-testing#readme) for installation and usage, and the [Node development guide](https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/node.md) for contributor instructions.
+This is an independent, non-official project.
+
+## Requirements
+
+- Node.js 22 or later
+- A `.bicepparam` entry point for the deployment under test
+
+## Installation
+
+```sh
+npm install --save-dev @anthony-c-martin/bicep-testing@0.1.2
+```
+
+## Snapshot testing
+
+Create one session for the test suite, evaluate the parameters file during setup, and dispose the session when the suite completes:
+
+```js
+const { BicepTestSession } = require('@anthony-c-martin/bicep-testing');
+
+let session;
+let snapshot;
+
+beforeAll(async () => {
+  session = await BicepTestSession.create('0.43.1');
+  snapshot = await session.snapshot(
+    'infra/main.bicepparam',
+    '00000000-0000-0000-0000-000000000000',
+    '00000000-0000-0000-0000-000000000000',
+    'example-rg',
+    'eastus',
+    'example-deployment',
+  );
+}, 60_000);
+
+afterAll(() => session.dispose());
+
+test('storage accounts disable public blob access', () => {
+  const storageAccounts = snapshot.predictedResources.filter(
+    resource => resource.type === 'Microsoft.Storage/storageAccounts',
+  );
+
+  expect(snapshot.diagnostics).toHaveLength(0);
+  expect(storageAccounts.length).toBeGreaterThan(0);
+  storageAccounts.forEach(resource => {
+    expect(resource.properties.allowBlobPublicAccess).toBe(false);
+  });
+});
+```
+
+`BicepTestSession.create()` downloads the requested Bicep CLI version into `~/.bicep/bin` and reuses it on later runs. The session owns a Bicep process, so always call `dispose()` after the tests finish.
+
+Snapshot tests run locally. The subscription, tenant, resource group, location, and deployment values provide evaluation context only; they do not need to exist, and no Azure credentials are required.
+
+## Snapshot results
+
+`snapshot()` returns:
+
+- `predictedResources`: resources and resolved properties predicted for the deployment
+- `outputs`: resolved deployment outputs
+- `diagnostics`: Bicep compilation warnings and errors
+
+## Live deployment testing
+
+Use `deploy()` only when a test must inspect a real Azure resource or service response:
+
+```js
+const { DefaultAzureCredential } = require('@azure/identity');
+
+const deployment = await session.deploy(new DefaultAzureCredential(), {
+  filePath: 'infra/main.bicepparam',
+  subscriptionId: process.env.AZURE_SUBSCRIPTION_ID,
+  resourceGroup: process.env.AZURE_RESOURCE_GROUP,
+  stackName: `bicep-test-${Date.now()}`,
+  parameterOverrides: { env: 'integration' },
+});
+
+try {
+  expect(deployment.resources).toEqual(expect.arrayContaining([
+    expect.objectContaining({ type: 'Microsoft.Storage/storageAccounts' }),
+  ]));
+} finally {
+  await deployment.teardown();
+}
+```
+
+Live tests require Azure credentials, an existing resource group, and permission to create and delete Deployment Stacks and their managed resources. `teardown()` is idempotent and deletes the stack and all resources it manages. Use a unique stack name and keep teardown in a `finally` block.
+
+## More information
+
+- [Runnable Jest snapshot and deployment samples](https://github.com/anthony-c-martin/bicep-testing/tree/main/samples/node)
+- [Complete Node guide](https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/node.md)
+- [Exported API](https://github.com/anthony-c-martin/bicep-testing/blob/main/api/node/bicep-testing.d.ts)
+- [Project repository](https://github.com/anthony-c-martin/bicep-testing)# @anthony-c-martin/bicep-testing
+
+Test the resources, outputs, and diagnostics produced by a Bicep deployment without deploying to Azure. The package can also run opt-in integration tests against a real Azure Deployment Stack when an assertion requires live resources.
+
+This is an independent, non-official project.
+
+## Requirements
+
+- Node.js 22 or later
+- A `.bicepparam` entry point for the deployment under test
+
+## Installation
+
+```sh
+npm install --save-dev @anthony-c-martin/bicep-testing@0.1.2
+```
+
+## Snapshot testing
+
+Create one session for the test suite, evaluate the parameters file during setup, and dispose the session when the suite completes:
+
+```js
+const { BicepTestSession } = require('@anthony-c-martin/bicep-testing');
+
+let session;
+let snapshot;
+
+beforeAll(async () => {
+	session = await BicepTestSession.create('0.43.1');
+	snapshot = await session.snapshot(
+		'infra/main.bicepparam',
+		'00000000-0000-0000-0000-000000000000',
+		'00000000-0000-0000-0000-000000000000',
+		'example-rg',
+		'eastus',
+		'example-deployment',
+	);
+}, 60_000);
+
+afterAll(() => session.dispose());
+
+test('storage accounts disable public blob access', () => {
+	const storageAccounts = snapshot.predictedResources.filter(
+		resource => resource.type === 'Microsoft.Storage/storageAccounts',
+	);
+
+	expect(snapshot.diagnostics).toHaveLength(0);
+	expect(storageAccounts.length).toBeGreaterThan(0);
+	storageAccounts.forEach(resource => {
+		expect(resource.properties.allowBlobPublicAccess).toBe(false);
+	});
+});
+```
+
+`BicepTestSession.create()` downloads the requested Bicep CLI version into `~/.bicep/bin` and reuses it on later runs. The session owns a Bicep process, so always call `dispose()` after the tests finish.
+
+Snapshot tests run locally. The subscription, tenant, resource group, location, and deployment values provide evaluation context only; they do not need to exist, and no Azure credentials are required.
+
+## Snapshot results
+
+`snapshot()` returns:
+
+- `predictedResources`: resources and resolved properties predicted for the deployment
+- `outputs`: resolved deployment outputs
+- `diagnostics`: Bicep compilation warnings and errors
+
+## Live deployment testing
+
+Use `deploy()` only when a test must inspect a real Azure resource or service response:
+
+```js
+const { DefaultAzureCredential } = require('@azure/identity');
+
+const deployment = await session.deploy(new DefaultAzureCredential(), {
+	filePath: 'infra/main.bicepparam',
+	subscriptionId: process.env.AZURE_SUBSCRIPTION_ID,
+	resourceGroup: process.env.AZURE_RESOURCE_GROUP,
+	stackName: `bicep-test-${Date.now()}`,
+	parameterOverrides: { env: 'integration' },
+});
+
+try {
+	expect(deployment.resources).toEqual(expect.arrayContaining([
+		expect.objectContaining({ type: 'Microsoft.Storage/storageAccounts' }),
+	]));
+} finally {
+	await deployment.teardown();
+}
+```
+
+Live tests require Azure credentials, an existing resource group, and permission to create and delete Deployment Stacks and their managed resources. `teardown()` is idempotent and deletes the stack and all resources it manages. Use a unique stack name and keep teardown in a `finally` block.
+
+## More information
+
+- [Runnable Jest snapshot and deployment samples](https://github.com/anthony-c-martin/bicep-testing/tree/main/samples/node)
+- [Complete Node guide](https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/node.md)
+- [Exported API](https://github.com/anthony-c-martin/bicep-testing/blob/main/api/node/bicep-testing.d.ts)
+- [Project repository](https://github.com/anthony-c-martin/bicep-testing)

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthony-c-martin/bicep-testing",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthony-c-martin/bicep-testing",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@azure/arm-resourcesdeploymentstacks": "^2.0.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthony-c-martin/bicep-testing",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Test library for interacting with the Bicep CLI.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/powershell/AnthonyCMartin.BicepTesting/AnthonyCMartin.BicepTesting.psd1
+++ b/packages/powershell/AnthonyCMartin.BicepTesting/AnthonyCMartin.BicepTesting.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'AnthonyCMartin.BicepTesting.psm1'
-    ModuleVersion = '0.1.1'
+    ModuleVersion = '0.1.2'
     GUID = 'ba8897af-e89f-4657-a30d-d1c9e9816070'
     Author = 'Anthony Martin'
     Description = 'Test Bicep infrastructure by evaluating deployment snapshots locally.'

--- a/packages/powershell/README.md
+++ b/packages/powershell/README.md
@@ -1,0 +1,90 @@
+# AnthonyCMartin.BicepTesting
+
+Test the resources, outputs, and diagnostics produced by a Bicep deployment without deploying to Azure. The module can also run opt-in integration tests against a real Azure Deployment Stack when an assertion requires live resources.
+
+This is an independent, non-official project.
+
+## Requirements
+
+- PowerShell 7.6 or later
+- A `.bicepparam` entry point for the deployment under test
+
+## Installation
+
+```powershell
+Install-PSResource AnthonyCMartin.BicepTesting -Version 0.1.2 -Repository PSGallery
+Import-Module AnthonyCMartin.BicepTesting -RequiredVersion 0.1.2
+```
+
+## Snapshot testing
+
+Create one session for the test suite and remove it when the suite completes:
+
+```powershell
+BeforeAll {
+    $session = New-BicepTestSession -BicepVersion '0.43.1'
+    $snapshot = $session | Get-BicepSnapshot `
+        -Path 'infra/main.bicepparam' `
+        -TenantId '00000000-0000-0000-0000-000000000000' `
+        -SubscriptionId '00000000-0000-0000-0000-000000000000' `
+        -ResourceGroup 'example-rg' `
+        -Location 'eastus' `
+        -DeploymentName 'example-deployment'
+}
+
+AfterAll {
+    $session | Remove-BicepTestSession
+}
+
+Describe 'Bicep infrastructure' {
+    It 'disables public blob access' {
+        $snapshot.Diagnostics | Should -BeNullOrEmpty
+        $storageAccounts = $snapshot.PredictedResources |
+            Where-Object Type -eq 'Microsoft.Storage/storageAccounts'
+        $storageAccounts | Should -Not -BeNullOrEmpty
+        $storageAccounts.Properties.GetProperty('allowBlobPublicAccess').GetBoolean() |
+            Should -Not -Contain $true
+    }
+}
+```
+
+`New-BicepTestSession` downloads the requested Bicep CLI version and reuses it on later runs. The session owns a Bicep process, so always call `Remove-BicepTestSession` in `AfterAll` or a `finally` block.
+
+Snapshot tests run locally. The subscription, tenant, resource group, location, and deployment values provide evaluation context only; they do not need to exist, and no Azure credentials are required.
+
+## Snapshot results
+
+`Get-BicepSnapshot` returns:
+
+- `PredictedResources`: resources and resolved properties predicted for the deployment
+- `Outputs`: resolved deployment outputs
+- `Diagnostics`: Bicep compilation warnings and errors
+
+## Live deployment testing
+
+Use `Start-BicepTestDeployment` only when a test must inspect a real Azure resource or service response:
+
+```powershell
+$deployment = $session | Start-BicepTestDeployment `
+    -Credential $credential `
+    -Path 'infra/main.bicepparam' `
+    -SubscriptionId $env:AZURE_SUBSCRIPTION_ID `
+    -ResourceGroup $env:AZURE_RESOURCE_GROUP `
+    -StackName "bicep-test-$([guid]::NewGuid().ToString('N'))"
+
+try {
+    $deployment.Resources.Type | Should -Contain 'Microsoft.Storage/storageAccounts'
+}
+finally {
+    $deployment | Remove-BicepTestDeployment
+}
+```
+
+Live tests require an Azure `TokenCredential`, an existing resource group, and permission to create and delete Deployment Stacks and their managed resources. `Remove-BicepTestDeployment` is idempotent and deletes the stack and all resources it manages. Use a unique stack name and keep removal in a `finally` block.
+
+## More information
+
+- [Runnable Pester snapshot and deployment samples](https://github.com/anthony-c-martin/bicep-testing/tree/main/samples/powershell)
+- [Complete PowerShell guide](https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/powershell.md)
+- [Exported commands](https://github.com/anthony-c-martin/bicep-testing/blob/main/api/powershell/AnthonyCMartin.BicepTesting.txt)
+- [Project repository](https://github.com/anthony-c-martin/bicep-testing)

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -1,11 +1,95 @@
 # Bicep Testing for Python
 
-`anthonycmartin-bicep-testing` evaluates Bicep deployment snapshots locally and supports opt-in live deployment tests through idiomatic Python APIs.
+Test the resources, outputs, and diagnostics produced by a Bicep deployment without deploying to Azure. The package can also run opt-in integration tests against a real Azure Deployment Stack when an assertion requires live resources.
 
-## Install
+This is an independent, non-official project.
+
+## Requirements
+
+- Python 3.11 or later
+- A `.bicepparam` entry point for the deployment under test
+
+## Installation
 
 ```sh
-python -m pip install anthonycmartin-bicep-testing==0.1.1
+python -m pip install anthonycmartin-bicep-testing==0.1.2
 ```
 
-See the [Python documentation](https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/python.md) for usage and lifecycle examples.
+## Snapshot testing
+
+Use `BicepTestSession` as a context manager so its Bicep process is always closed:
+
+```python
+from anthonycmartin.bicep_testing import BicepTestSession, SnapshotMetadata
+
+metadata = SnapshotMetadata(
+	tenant_id="00000000-0000-0000-0000-000000000000",
+	subscription_id="00000000-0000-0000-0000-000000000000",
+	resource_group="example-rg",
+	location="eastus",
+	deployment_name="example-deployment",
+)
+
+with BicepTestSession.create("0.43.1") as session:
+	snapshot = session.snapshot("infra/main.bicepparam", metadata)
+
+storage_accounts = [
+	resource
+	for resource in snapshot.predicted_resources
+	if resource.type == "Microsoft.Storage/storageAccounts"
+]
+assert snapshot.diagnostics == ()
+assert storage_accounts
+assert all(
+	resource.properties["allowBlobPublicAccess"] is False
+	for resource in storage_accounts
+)
+```
+
+`BicepTestSession.create()` downloads the requested Bicep CLI version into `~/.bicep/bin` and reuses it on later runs. The session owns a Bicep process, so use it as a context manager or call `close()` after the tests finish.
+
+Snapshot tests run locally. The subscription, tenant, resource group, location, and deployment values provide evaluation context only; they do not need to exist, and no Azure credentials are required.
+
+## Snapshot results
+
+`snapshot()` returns an immutable `SnapshotResult` containing:
+
+- `predicted_resources`: resources and resolved properties predicted for the deployment
+- `outputs`: resolved deployment outputs
+- `diagnostics`: Bicep compilation warnings and errors
+
+Each resource exposes its name, type, API version, location, properties, and additional fields returned by Bicep.
+
+## Live deployment testing
+
+Use `deploy()` only when a test must inspect a real Azure resource or service response. The result is also a context manager, so teardown runs when an assertion fails:
+
+```python
+import uuid
+
+from azure.identity import DefaultAzureCredential
+
+with session.deploy(
+	DefaultAzureCredential(),
+	"infra/main.bicepparam",
+	subscription_id,
+	resource_group,
+	f"bicep-test-{uuid.uuid4().hex}",
+	{"env": "integration"},
+) as deployment:
+	assert any(
+		resource.type == "Microsoft.Storage/storageAccounts"
+		for resource in deployment.resources
+	)
+```
+
+Live tests require Azure credentials, an existing resource group, and permission to create and delete Deployment Stacks and their managed resources. Closing the result is idempotent and deletes the stack and all resources it manages. Use a unique stack name and keep the result in a context manager.
+
+Lower-level Bicep integrations can use the separately distributed [`anthonycmartin-bicep-rpc-client`](https://github.com/anthony-c-martin/bicep-testing/tree/main/packages/python/bicep_rpc_client).
+
+## More information
+
+- [Runnable pytest snapshot and deployment samples](https://github.com/anthony-c-martin/bicep-testing/tree/main/samples/python)
+- [Complete Python guide](https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/python.md)
+- [Exported API](https://github.com/anthony-c-martin/bicep-testing/blob/main/api/python/bicep-testing.txt)
+- [Project repository](https://github.com/anthony-c-martin/bicep-testing)

--- a/packages/python/bicep_rpc_client/README.md
+++ b/packages/python/bicep_rpc_client/README.md
@@ -7,7 +7,7 @@ An independent Python client for programmatically interacting with the [Bicep CL
 ### Install the package
 
 ```sh
-python -m pip install anthonycmartin-bicep-rpc-client==0.1.1
+python -m pip install anthonycmartin-bicep-rpc-client==0.1.2
 ```
 
 The distribution is named `anthonycmartin-bicep-rpc-client`; import its public API from `anthonycmartin.bicep_rpc_client`.

--- a/packages/python/bicep_rpc_client/pyproject.toml
+++ b/packages/python/bicep_rpc_client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anthonycmartin-bicep-rpc-client"
-version = "0.1.1"
+version = "0.1.2"
 description = "Interact with the Bicep CLI through its JSON-RPC API."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anthonycmartin-bicep-testing"
-version = "0.1.1"
+version = "0.1.2"
 description = "Test Bicep infrastructure by evaluating deployment snapshots locally."
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
 authors = [{ name = "Anthony Martin" }]
 dependencies = [
-	"anthonycmartin-bicep-rpc-client>=0.1.1",
+	"anthonycmartin-bicep-rpc-client>=0.1.2",
 	"azure-mgmt-resource-deploymentstacks==1.0.0",
 ]
 

--- a/scripts/ValidateSamples.ps1
+++ b/scripts/ValidateSamples.ps1
@@ -38,7 +38,7 @@ try {
     }
 
     Write-Host 'Installing and parsing the PowerShell sample tests...'
-    Install-PSResource AnthonyCMartin.BicepTesting -Version 0.1.1 -Repository PSGallery -Scope CurrentUser -TrustRepository -Reinstall -Quiet
+    Install-PSResource AnthonyCMartin.BicepTesting -Version 0.1.2 -Repository PSGallery -Scope CurrentUser -TrustRepository -Reinstall -Quiet
     Invoke-NativeCommand {
         pwsh -NoProfile -Command '$errors = @(); Get-ChildItem ./samples/powershell -Filter *.ps1 | ForEach-Object { [void][Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$null, [ref]$errors) }; if ($errors) { $errors | Out-String | Write-Error; exit 1 }'
     } 'PowerShell sample parsing'

--- a/site/index.html
+++ b/site/index.html
@@ -96,28 +96,28 @@
 
         <div class="install-panels">
           <div class="install-panel" role="tabpanel" id="panel-node" aria-labelledby="tab-node" data-panel="node">
-            <div class="install-meta"><span>npm</span><span>Node.js 22+</span><span>v0.1.1</span></div>
-            <div class="command-row"><code>npm install --save-dev @anthony-c-martin/bicep-testing@0.1.1</code><button class="copy-button" data-copy="npm install --save-dev @anthony-c-martin/bicep-testing@0.1.1" aria-label="Copy Node install command"><i data-lucide="copy" aria-hidden="true"></i></button></div>
+            <div class="install-meta"><span>npm</span><span>Node.js 22+</span><span>v0.1.2</span></div>
+            <div class="command-row"><code>npm install --save-dev @anthony-c-martin/bicep-testing@0.1.2</code><button class="copy-button" data-copy="npm install --save-dev @anthony-c-martin/bicep-testing@0.1.2" aria-label="Copy Node install command"><i data-lucide="copy" aria-hidden="true"></i></button></div>
             <a href="https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/node.md">Read the Node guide <i data-lucide="arrow-up-right" aria-hidden="true"></i></a>
           </div>
           <div class="install-panel" role="tabpanel" id="panel-csharp" aria-labelledby="tab-csharp" data-panel="csharp" hidden>
-            <div class="install-meta"><span>NuGet</span><span>.NET 10+</span><span>v0.1.1</span></div>
-            <div class="command-row"><code>dotnet add package AnthonyCMartin.BicepTesting --version 0.1.1</code><button class="copy-button" data-copy="dotnet add package AnthonyCMartin.BicepTesting --version 0.1.1" aria-label="Copy C# install command"><i data-lucide="copy" aria-hidden="true"></i></button></div>
+            <div class="install-meta"><span>NuGet</span><span>.NET 10+</span><span>v0.1.2</span></div>
+            <div class="command-row"><code>dotnet add package AnthonyCMartin.BicepTesting --version 0.1.2</code><button class="copy-button" data-copy="dotnet add package AnthonyCMartin.BicepTesting --version 0.1.2" aria-label="Copy C# install command"><i data-lucide="copy" aria-hidden="true"></i></button></div>
             <a href="https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/csharp.md">Read the C# guide <i data-lucide="arrow-up-right" aria-hidden="true"></i></a>
           </div>
           <div class="install-panel" role="tabpanel" id="panel-go" aria-labelledby="tab-go" data-panel="go" hidden>
-            <div class="install-meta"><span>Go modules</span><span>Go 1.24+</span><span>v0.1.1</span></div>
-            <div class="command-row"><code>go get github.com/anthony-c-martin/bicep-testing/packages/go@v0.1.1</code><button class="copy-button" data-copy="go get github.com/anthony-c-martin/bicep-testing/packages/go@v0.1.1" aria-label="Copy Go install command"><i data-lucide="copy" aria-hidden="true"></i></button></div>
+            <div class="install-meta"><span>Go modules</span><span>Go 1.24+</span><span>v0.1.2</span></div>
+            <div class="command-row"><code>go get github.com/anthony-c-martin/bicep-testing/packages/go@v0.1.2</code><button class="copy-button" data-copy="go get github.com/anthony-c-martin/bicep-testing/packages/go@v0.1.2" aria-label="Copy Go install command"><i data-lucide="copy" aria-hidden="true"></i></button></div>
             <a href="https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/go.md">Read the Go guide <i data-lucide="arrow-up-right" aria-hidden="true"></i></a>
           </div>
           <div class="install-panel" role="tabpanel" id="panel-powershell" aria-labelledby="tab-powershell" data-panel="powershell" hidden>
-            <div class="install-meta"><span>PowerShell Gallery</span><span>PowerShell 7.6+</span><span>v0.1.1</span></div>
-            <div class="command-row"><code>Install-PSResource AnthonyCMartin.BicepTesting -Version 0.1.1</code><button class="copy-button" data-copy="Install-PSResource AnthonyCMartin.BicepTesting -Version 0.1.1" aria-label="Copy PowerShell install command"><i data-lucide="copy" aria-hidden="true"></i></button></div>
+            <div class="install-meta"><span>PowerShell Gallery</span><span>PowerShell 7.6+</span><span>v0.1.2</span></div>
+            <div class="command-row"><code>Install-PSResource AnthonyCMartin.BicepTesting -Version 0.1.2</code><button class="copy-button" data-copy="Install-PSResource AnthonyCMartin.BicepTesting -Version 0.1.2" aria-label="Copy PowerShell install command"><i data-lucide="copy" aria-hidden="true"></i></button></div>
             <a href="https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/powershell.md">Read the PowerShell guide <i data-lucide="arrow-up-right" aria-hidden="true"></i></a>
           </div>
           <div class="install-panel" role="tabpanel" id="panel-python" aria-labelledby="tab-python" data-panel="python" hidden>
-            <div class="install-meta"><span>PyPI</span><span>Python 3.11+</span><span>v0.1.1</span></div>
-            <div class="command-row"><code>python -m pip install anthonycmartin-bicep-testing==0.1.1</code><button class="copy-button" data-copy="python -m pip install anthonycmartin-bicep-testing==0.1.1" aria-label="Copy Python install command"><i data-lucide="copy" aria-hidden="true"></i></button></div>
+            <div class="install-meta"><span>PyPI</span><span>Python 3.11+</span><span>v0.1.2</span></div>
+            <div class="command-row"><code>python -m pip install anthonycmartin-bicep-testing==0.1.2</code><button class="copy-button" data-copy="python -m pip install anthonycmartin-bicep-testing==0.1.2" aria-label="Copy Python install command"><i data-lucide="copy" aria-hidden="true"></i></button></div>
             <a href="https://github.com/anthony-c-martin/bicep-testing/blob/main/docs/python.md">Read the Python guide <i data-lucide="arrow-up-right" aria-hidden="true"></i></a>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- add detailed package-level READMEs for the .NET, Go, Node, PowerShell, and Python testing libraries
- include the .NET README in the generated NuGet package
- bump all first-party package manifests and installation references from 0.1.1 to 0.1.2
- update release documentation, sample validation, and website install commands for 0.1.2

## Validation

- verified no first-party `0.1.1` references remain (excluding unrelated third-party Go checksums)
- verified the combined Git patch passes whitespace validation
- checked package manifest diagnostics; the Go language server check was environment-limited by its root-owned module cache