### PR TITLE
Add real-world infrastructure testing samples

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Keep source, configuration, documentation, and lockfiles consistent across platforms.
+* text=auto eol=lf
+
+# Windows command scripts require CRLF for compatibility with cmd.exe.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Never apply line-ending conversion to binary archives, packages, or media.
+*.dll binary
+*.exe binary
+*.gif binary
+*.ico binary
+*.jpeg binary
+*.jpg binary
+*.nupkg binary
+*.pdf binary
+*.png binary
+*.snupkg binary
+*.tar binary
+*.tgz binary
+*.webp binary
+*.whl binary
+*.zip binary

--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ Lower-level Bicep CLI integrations are published as the Go `bicep-rpc-client` mo
 
 ## Samples
 
-Runnable test suites under [`samples/`](samples/) demonstrate the same credential-free snapshot assertions and opt-in live deployment workflow with Jest, MSTest, Go's `testing` package, Pester, and pytest. They share one Bicep fixture. Standard CI compiles or collects the samples without executing tests, so it validates both workflows without requiring Azure credentials or creating resources. See the [sample instructions](samples/README.md) for the environment variables required to run the live tests.
+Runnable test suites under [`samples/`](samples/) demonstrate three credential-free snapshot scenarios and two opt-in live deployment scenarios with Jest, MSTest, Go's `testing` package, Pester, and pytest. Every language uses the same shared Bicep fixtures and equivalent assertions. Standard CI compiles or collects the samples without requiring Azure credentials or creating resources. See the [sample instructions](samples/README.md) for the scenario catalog and the environment variables required to run the live tests.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for repository setup, build commands, tests, and project conventions.

--- a/samples/README.md
+++ b/samples/README.md
@@ -8,7 +8,22 @@ Each language demonstrates both local snapshot assertions and an opt-in live Azu
 - [PowerShell](powershell/) uses Pester.
 - [Python](python/) uses pytest.
 
-All samples share [`infra/main.bicepparam`](infra/main.bicepparam). Snapshot tests predict its resources without Azure credentials. Deployment tests compile it, create an Azure Deployment Stack, assert against the resulting resources and outputs, and delete the stack and its managed resources during cleanup.
+All languages exercise the same shared Bicep fixtures and equivalent assertions.
+
+## Offline snapshot scenarios
+
+- **Environment topology** evaluates separate development and production parameter files, checking conditional resources, storage SKUs, names, tags, and outputs.
+- **Security baseline** verifies hardened Storage and Key Vault properties and demonstrates how a deliberately weakened parameter set exposes a regression.
+- **Private network wiring** checks VNet and subnet address plans, NSG associations, private endpoint connections, private DNS links, and output contracts.
+
+Snapshot tests evaluate these scenarios locally without Azure credentials or a subscription.
+
+## Live deployment scenarios
+
+- **Secure storage** deploys an ephemeral storage account, verifies its security properties through an authenticated Azure Resource Manager request, and confirms teardown removed it.
+- **Deployment reconciliation** deploys primary and audit storage accounts, updates the same Deployment Stack to remove the audit account, verifies Azure reconciled the change, and confirms final teardown removed the remaining account.
+
+Both scenarios use [`infra/live-storage/main.bicepparam`](infra/live-storage/main.bicepparam) and inexpensive `Standard_LRS` storage accounts. Deployment tests always delete the stack and its managed resources during cleanup.
 
 Live deployment tests are skipped unless all of these environment variables are set:
 
@@ -27,4 +42,4 @@ Validate every sample from the repository root:
 
 The validator restores the published version 0.1.0 libraries and dependencies, then compiles, parses, or collects every sample test. It does not execute snapshot or live deployment tests, so standard CI remains credential-free and cannot create Azure resources.
 
-To run a language's tests, use its native test command after setting the live deployment environment variables. Without those variables, only the credential-free snapshot tests run and the deployment test is skipped.
+To run a language's tests, use its native test command after setting the live deployment environment variables. Without those variables, the three credential-free snapshot tests run and the two deployment tests are skipped.

--- a/samples/dotnet/DeploymentTests.cs
+++ b/samples/dotnet/DeploymentTests.cs
@@ -1,6 +1,9 @@
 using AnthonyCMartin.BicepTesting;
+using Azure.Core;
 using Azure.Identity;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Net;
+using System.Net.Http.Headers;
 using System.Text.Json;
 
 namespace Samples;
@@ -8,49 +11,136 @@ namespace Samples;
 [TestClass]
 public sealed class DeploymentTests
 {
+    private static readonly HttpClient HttpClient = new();
+
     public TestContext TestContext { get; set; } = null!;
 
     [TestMethod]
     [Timeout(15 * 60_000)]
-    public async Task Infrastructure_deploys_and_is_removed_afterward()
+    public async Task Secure_storage_is_verified_in_Azure_and_removed()
     {
-        var subscriptionId = RequireEnvironmentVariable("AZURE_SUBSCRIPTION_ID");
-        var resourceGroup = RequireEnvironmentVariable("AZURE_RESOURCE_GROUP");
-        var stackName = RequireEnvironmentVariable("BICEP_TEST_STACK_NAME");
-        var resourcePrefix = RequireEnvironmentVariable("BICEP_TEST_RESOURCE_PREFIX");
-        var parametersPath = Path.GetFullPath(
-            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "infra", "main.bicepparam"));
+        var settings = LiveSettings.Load();
+        var credential = new DefaultAzureCredential();
+        await using var session = await BicepTestSession.CreateAsync("0.43.1", TestContext.CancellationToken);
+        DeployResult? deployment = null;
+        string? primaryStorageId = null;
+        try
+        {
+            deployment = await DeployAsync(session, credential, settings, $"{settings.StackName}-secure", false);
+            primaryStorageId = deployment.Outputs["primaryStorageId"].GetString()!;
+            using var response = await GetAzureResourceAsync(credential, primaryStorageId);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            var storage = JsonDocument.Parse(await response.Content.ReadAsStringAsync(TestContext.CancellationToken));
+            var properties = storage.RootElement.GetProperty("properties");
+            Assert.IsFalse(properties.GetProperty("allowBlobPublicAccess").GetBoolean());
+            Assert.IsFalse(properties.GetProperty("allowSharedKeyAccess").GetBoolean());
+            Assert.AreEqual("TLS1_2", properties.GetProperty("minimumTlsVersion").GetString());
+            Assert.AreEqual("Disabled", properties.GetProperty("publicNetworkAccess").GetString());
+            Assert.IsTrue(properties.GetProperty("supportsHttpsTrafficOnly").GetBoolean());
+            Assert.IsTrue(deployment.Resources.Any(resource => resource.Id == primaryStorageId));
+        }
+        finally
+        {
+            if (deployment is not null)
+            {
+                await deployment.TeardownAsync(TestContext.CancellationToken);
+            }
+        }
 
-        await using var session = await AnthonyCMartin.BicepTesting.BicepTestSession.CreateAsync("0.43.1", TestContext.CancellationToken);
-        await using var deployment = await session.DeployAsync(
-            new DefaultAzureCredential(),
+        using var deleted = await GetAzureResourceAsync(credential, primaryStorageId!);
+        Assert.AreEqual(HttpStatusCode.NotFound, deleted.StatusCode);
+    }
+
+    [TestMethod]
+    [Timeout(20 * 60_000)]
+    public async Task Deployment_reconciles_removed_audit_storage_and_cleans_up()
+    {
+        var settings = LiveSettings.Load();
+        var credential = new DefaultAzureCredential();
+        await using var session = await BicepTestSession.CreateAsync("0.43.1", TestContext.CancellationToken);
+        DeployResult? reconciled = null;
+        string? primaryStorageId = null;
+        string? auditStorageId = null;
+        try
+        {
+            var initial = await DeployAsync(session, credential, settings, settings.StackName, true);
+            primaryStorageId = initial.Outputs["primaryStorageId"].GetString()!;
+            auditStorageId = initial.Outputs["auditStorageId"].GetString()!;
+            Assert.HasCount(2, initial.Resources);
+
+            reconciled = await DeployAsync(session, credential, settings, settings.StackName, false);
+            Assert.HasCount(1, reconciled.Resources);
+            Assert.AreEqual(primaryStorageId, reconciled.Resources[0].Id);
+            using var removedAudit = await GetAzureResourceAsync(credential, auditStorageId);
+            Assert.AreEqual(HttpStatusCode.NotFound, removedAudit.StatusCode);
+        }
+        finally
+        {
+            if (reconciled is not null)
+            {
+                await reconciled.TeardownAsync(TestContext.CancellationToken);
+            }
+        }
+
+        using var removedPrimary = await GetAzureResourceAsync(credential, primaryStorageId!);
+        Assert.AreEqual(HttpStatusCode.NotFound, removedPrimary.StatusCode);
+    }
+
+    private async Task<DeployResult> DeployAsync(
+        BicepTestSession session,
+        TokenCredential credential,
+        LiveSettings settings,
+        string stackName,
+        bool includeAuditStorage)
+    {
+        return await session.DeployAsync(
+            credential,
             new DeployOptions
             {
-                FilePath = parametersPath,
-                SubscriptionId = subscriptionId,
-                ResourceGroup = resourceGroup,
+                FilePath = InfraPath("live-storage/main.bicepparam"),
+                SubscriptionId = settings.SubscriptionId,
+                ResourceGroup = settings.ResourceGroup,
                 StackName = stackName,
                 ParameterOverrides = new Dictionary<string, JsonElement>
                 {
-                    ["env"] = JsonSerializer.SerializeToElement(resourcePrefix),
+                    ["resourcePrefix"] = JsonSerializer.SerializeToElement(settings.ResourcePrefix),
+                    ["includeAuditStorage"] = JsonSerializer.SerializeToElement(includeAuditStorage),
                 },
             },
             TestContext.CancellationToken);
-
-        Assert.IsTrue(deployment.Resources.Any(resource =>
-            resource.Type == "Microsoft.Storage/storageAccounts"));
-        StringAssert.Contains(
-            deployment.Outputs["primaryStorageId"].GetString(),
-            "/providers/Microsoft.Storage/storageAccounts/");
     }
 
-    private static string RequireEnvironmentVariable(string name)
+    private async Task<HttpResponseMessage> GetAzureResourceAsync(TokenCredential credential, string resourceId)
     {
-        var value = Environment.GetEnvironmentVariable(name);
-        if (string.IsNullOrWhiteSpace(value))
+        var token = await credential.GetTokenAsync(
+            new TokenRequestContext(["https://management.azure.com/.default"]),
+            TestContext.CancellationToken);
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"https://management.azure.com{resourceId}?api-version=2023-05-01");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+        return await HttpClient.SendAsync(request, TestContext.CancellationToken);
+    }
+
+    private static string InfraPath(string relativePath) => Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "infra", relativePath));
+
+    private sealed record LiveSettings(string SubscriptionId, string ResourceGroup, string StackName, string ResourcePrefix)
+    {
+        public static LiveSettings Load() => new(
+            Require("AZURE_SUBSCRIPTION_ID"),
+            Require("AZURE_RESOURCE_GROUP"),
+            Require("BICEP_TEST_STACK_NAME"),
+            Require("BICEP_TEST_RESOURCE_PREFIX"));
+
+        private static string Require(string name)
         {
-            Assert.Inconclusive($"Set {name} to run the live deployment sample.");
+            var value = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                Assert.Inconclusive($"Set {name} to run the live deployment samples.");
+            }
+            return value!;
         }
-        return value!;
     }
 }

--- a/samples/dotnet/SnapshotTests.cs
+++ b/samples/dotnet/SnapshotTests.cs
@@ -1,37 +1,108 @@
 using AnthonyCMartin.BicepTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
 
 namespace Samples;
 
 [TestClass]
 public sealed class SnapshotTests
 {
+    private const string TenantId = "ddbe463a-0554-485d-b589-0b17d60cd38b";
+    private const string SubscriptionId = "28c9069e-23e8-47d2-b640-00d2e0f09616";
+
     public TestContext TestContext { get; set; } = null!;
 
     [TestMethod]
     [Timeout(60_000)]
-    public async Task Infrastructure_has_expected_resources_and_no_diagnostics()
+    public async Task Environment_parameters_select_topology_skus_and_tags()
     {
-        var parametersPath = Path.GetFullPath(
-            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "infra", "main.bicepparam"));
-
         await using var session = await BicepTestSession.CreateAsync("0.43.1", TestContext.CancellationToken);
-        var snapshot = await session.SnapshotAsync(
-            parametersPath,
-            "00000000-0000-0000-0000-000000000000",
-            "00000000-0000-0000-0000-000000000000",
+        var development = await SnapshotAsync(session, "environment-topology/dev.bicepparam");
+        var production = await SnapshotAsync(session, "environment-topology/prod.bicepparam");
+
+        Assert.IsEmpty(development.Diagnostics);
+        Assert.HasCount(1, development.PredictedResources);
+        var developmentStorage = development.PredictedResources[0];
+        Assert.AreEqual("ordersdevprimary", developmentStorage.Name);
+        Assert.AreEqual("Standard_LRS", Extra(developmentStorage, "sku").GetProperty("name").GetString());
+        Assert.AreEqual("dev", Extra(developmentStorage, "tags").GetProperty("environment").GetString());
+        Assert.AreEqual(JsonValueKind.Null, development.Outputs["auditStorageId"].ValueKind);
+
+        CollectionAssert.AreEqual(
+            new[] { "ordersprodprimary", "ordersprodaudit" },
+            production.PredictedResources.Select(resource => resource.Name).ToArray());
+        Assert.AreEqual("Standard_ZRS", Extra(production.PredictedResources[0], "sku").GetProperty("name").GetString());
+        Assert.AreEqual("confidential", Extra(production.PredictedResources[0], "tags").GetProperty("dataClassification").GetString());
+        Assert.AreEqual("Standard_GRS", Extra(production.PredictedResources[1], "sku").GetProperty("name").GetString());
+        StringAssert.Contains(production.Outputs["auditStorageId"].GetString(), "/storageAccounts/ordersprodaudit");
+    }
+
+    [TestMethod]
+    [Timeout(60_000)]
+    public async Task Security_baseline_catches_weakened_parameters()
+    {
+        await using var session = await BicepTestSession.CreateAsync("0.43.1", TestContext.CancellationToken);
+        var secure = await SnapshotAsync(session, "security-baseline/secure.bicepparam");
+        var insecure = await SnapshotAsync(session, "security-baseline/insecure.bicepparam");
+        var secureStorage = Resource(secure, "Microsoft.Storage/storageAccounts");
+        var secureVault = Resource(secure, "Microsoft.KeyVault/vaults");
+        var insecureStorage = Resource(insecure, "Microsoft.Storage/storageAccounts");
+
+        Assert.IsEmpty(secure.Diagnostics);
+        Assert.IsFalse(secureStorage.Properties.GetProperty("allowBlobPublicAccess").GetBoolean());
+        Assert.IsFalse(secureStorage.Properties.GetProperty("allowSharedKeyAccess").GetBoolean());
+        Assert.AreEqual("TLS1_2", secureStorage.Properties.GetProperty("minimumTlsVersion").GetString());
+        Assert.AreEqual("Disabled", secureStorage.Properties.GetProperty("publicNetworkAccess").GetString());
+        Assert.IsTrue(secureVault.Properties.GetProperty("enablePurgeProtection").GetBoolean());
+        Assert.IsTrue(secureVault.Properties.GetProperty("enableRbacAuthorization").GetBoolean());
+        Assert.AreEqual(90, secureVault.Properties.GetProperty("softDeleteRetentionInDays").GetInt32());
+        Assert.AreEqual("TLS1_0", insecureStorage.Properties.GetProperty("minimumTlsVersion").GetString());
+        Assert.IsTrue(insecureStorage.Properties.GetProperty("allowBlobPublicAccess").GetBoolean());
+    }
+
+    [TestMethod]
+    [Timeout(60_000)]
+    public async Task Private_network_references_are_wired_together()
+    {
+        await using var session = await BicepTestSession.CreateAsync("0.43.1", TestContext.CancellationToken);
+        var snapshot = await SnapshotAsync(session, "private-network/main.bicepparam");
+        var resources = snapshot.PredictedResources.ToDictionary(resource => resource.Name);
+        var networkIds = snapshot.Outputs["networkIds"];
+
+        Assert.IsEmpty(snapshot.Diagnostics);
+        Assert.AreEqual("10.42.0.0/16", resources["orders-vnet"].Properties.GetProperty("addressSpace").GetProperty("addressPrefixes")[0].GetString());
+        Assert.AreEqual("10.42.1.0/24", resources["orders-vnet/app"].Properties.GetProperty("addressPrefix").GetString());
+        StringAssert.Contains(resources["orders-vnet/app"].Properties.GetProperty("networkSecurityGroup").GetProperty("id").GetString(), "/orders-app-nsg");
+        Assert.AreEqual("Disabled", resources["orders-vnet/data"].Properties.GetProperty("privateEndpointNetworkPolicies").GetString());
+        Assert.AreEqual(
+            networkIds.GetProperty("dataSubnetId").GetString(),
+            resources["orders-storage-pe"].Properties.GetProperty("subnet").GetProperty("id").GetString());
+        var connection = resources["orders-storage-pe"].Properties.GetProperty("privateLinkServiceConnections")[0].GetProperty("properties");
+        Assert.AreEqual("blob", connection.GetProperty("groupIds")[0].GetString());
+        StringAssert.Contains(connection.GetProperty("privateLinkServiceId").GetString(), "/storageAccounts/ordersprivatestore");
+        Assert.AreEqual(
+            networkIds.GetProperty("virtualNetworkId").GetString(),
+            resources["privatelink.blob.core.windows.net/orders-vnet-link"].Properties.GetProperty("virtualNetwork").GetProperty("id").GetString());
+    }
+
+    private async Task<SnapshotResult> SnapshotAsync(BicepTestSession session, string relativePath)
+    {
+        return await session.SnapshotAsync(
+            InfraPath(relativePath),
+            TenantId,
+            SubscriptionId,
             "sample-rg",
             "eastus",
             "sample-deployment",
             TestContext.CancellationToken);
-
-        Assert.IsEmpty(snapshot.Diagnostics);
-        Assert.HasCount(3, snapshot.PredictedResources);
-        Assert.IsTrue(snapshot.PredictedResources.Any(resource =>
-            resource.Type == "Microsoft.Storage/storageAccounts" && resource.Name == "sampleprimary"));
-        Assert.IsTrue(snapshot.PredictedResources.Any(resource =>
-            resource.Type == "Microsoft.Storage/storageAccounts" && resource.Name == "samplebackup"));
-        Assert.IsTrue(snapshot.PredictedResources.Any(resource =>
-            resource.Type == "Microsoft.KeyVault/vaults" && resource.Name == "samplekv"));
     }
+
+    private static SnapshotResource Resource(SnapshotResult snapshot, string type) =>
+        snapshot.PredictedResources.Single(resource => resource.Type == type);
+
+    private static JsonElement Extra(SnapshotResource resource, string name) =>
+        resource.AdditionalProperties![name];
+
+    private static string InfraPath(string relativePath) => Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "infra", relativePath));
 }

--- a/samples/go/deployment_test.go
+++ b/samples/go/deployment_test.go
@@ -3,28 +3,112 @@ package sample_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	biceptesting "github.com/anthony-c-martin/bicep-testing/packages/go"
 )
 
-func TestInfrastructureDeploysAndIsRemovedAfterward(t *testing.T) {
-	subscriptionID := requireEnvironmentVariable(t, "AZURE_SUBSCRIPTION_ID")
-	resourceGroup := requireEnvironmentVariable(t, "AZURE_RESOURCE_GROUP")
-	stackName := requireEnvironmentVariable(t, "BICEP_TEST_STACK_NAME")
-	resourcePrefix := requireEnvironmentVariable(t, "BICEP_TEST_RESOURCE_PREFIX")
-
+func TestSecureStorageIsVerifiedInAzureAndRemoved(t *testing.T) {
+	settings := loadLiveSettings(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 	credential, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	session := newLiveSession(t, ctx)
+	deployment := deployStorage(t, ctx, session, credential, settings, settings.stackName+"-secure", false)
+	primaryStorageID := deployment.Outputs["primaryStorageId"].(string)
+	defer func() {
+		if err := deployment.Teardown(context.Background()); err != nil {
+			t.Errorf("tear down deployment: %v", err)
+		}
+	}()
+
+	status, storage := getAzureResource(t, ctx, credential, primaryStorageID)
+	if status != http.StatusOK {
+		t.Fatalf("get storage account status = %d, want 200", status)
+	}
+	properties := storage["properties"].(map[string]any)
+	if properties["allowBlobPublicAccess"] != false || properties["allowSharedKeyAccess"] != false ||
+		properties["minimumTlsVersion"] != "TLS1_2" || properties["publicNetworkAccess"] != "Disabled" ||
+		properties["supportsHttpsTrafficOnly"] != true {
+		t.Errorf("storage security settings did not match: %#v", properties)
+	}
+
+	if err := deployment.Teardown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	status, _ = getAzureResource(t, ctx, credential, primaryStorageID)
+	if status != http.StatusNotFound {
+		t.Errorf("storage account status after teardown = %d, want 404", status)
+	}
+}
+
+func TestDeploymentReconcilesRemovedAuditStorageAndCleansUp(t *testing.T) {
+	settings := loadLiveSettings(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+	credential, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := newLiveSession(t, ctx)
+	initial := deployStorage(t, ctx, session, credential, settings, settings.stackName, true)
+	primaryStorageID := initial.Outputs["primaryStorageId"].(string)
+	auditStorageID := initial.Outputs["auditStorageId"].(string)
+	if len(initial.Resources) != 2 {
+		t.Fatalf("initial resources = %d, want 2", len(initial.Resources))
+	}
+
+	reconciled := deployStorage(t, ctx, session, credential, settings, settings.stackName, false)
+	defer func() {
+		if err := reconciled.Teardown(context.Background()); err != nil {
+			t.Errorf("tear down deployment: %v", err)
+		}
+	}()
+	if len(reconciled.Resources) != 1 || reconciled.Resources[0].ID != primaryStorageID {
+		t.Errorf("unexpected reconciled resources: %#v", reconciled.Resources)
+	}
+	if status, _ := getAzureResource(t, ctx, credential, auditStorageID); status != http.StatusNotFound {
+		t.Errorf("audit storage status after reconciliation = %d, want 404", status)
+	}
+	if err := reconciled.Teardown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if status, _ := getAzureResource(t, ctx, credential, primaryStorageID); status != http.StatusNotFound {
+		t.Errorf("primary storage status after teardown = %d, want 404", status)
+	}
+}
+
+type liveSettings struct {
+	subscriptionID string
+	resourceGroup  string
+	stackName      string
+	resourcePrefix string
+}
+
+func loadLiveSettings(t *testing.T) liveSettings {
+	t.Helper()
+	return liveSettings{
+		subscriptionID: requireEnvironmentVariable(t, "AZURE_SUBSCRIPTION_ID"),
+		resourceGroup:  requireEnvironmentVariable(t, "AZURE_RESOURCE_GROUP"),
+		stackName:      requireEnvironmentVariable(t, "BICEP_TEST_STACK_NAME"),
+		resourcePrefix: requireEnvironmentVariable(t, "BICEP_TEST_RESOURCE_PREFIX"),
+	}
+}
+
+func newLiveSession(t *testing.T, ctx context.Context) *biceptesting.Session {
+	t.Helper()
 	session, err := biceptesting.NewSession(ctx, "0.43.1")
 	if err != nil {
 		t.Fatal(err)
@@ -34,45 +118,58 @@ func TestInfrastructureDeploysAndIsRemovedAfterward(t *testing.T) {
 			t.Errorf("close session: %v", err)
 		}
 	})
-	parametersPath, err := filepath.Abs(filepath.Join("..", "infra", "main.bicepparam"))
+	return session
+}
+
+func deployStorage(t *testing.T, ctx context.Context, session *biceptesting.Session, credential azcore.TokenCredential, settings liveSettings, stackName string, includeAudit bool) *biceptesting.DeployResult {
+	t.Helper()
+	parametersPath, err := filepath.Abs(filepath.Join("..", "infra", "live-storage", "main.bicepparam"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	deployment, err := session.Deploy(ctx, credential, biceptesting.DeployOptions{
-		FilePath:       parametersPath,
-		SubscriptionID: subscriptionID,
-		ResourceGroup:  resourceGroup,
-		StackName:      stackName,
+		FilePath: parametersPath, SubscriptionID: settings.subscriptionID, ResourceGroup: settings.resourceGroup, StackName: stackName,
 		ParameterOverrides: map[string]json.RawMessage{
-			"env": json.RawMessage(strconv.Quote(resourcePrefix)),
+			"resourcePrefix":      json.RawMessage(strconv.Quote(settings.resourcePrefix)),
+			"includeAuditStorage": json.RawMessage(strconv.FormatBool(includeAudit)),
 		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		if err := deployment.Teardown(context.Background()); err != nil {
-			t.Errorf("tear down deployment: %v", err)
-		}
-	})
+	return deployment
+}
 
-	foundStorageAccount := false
-	for _, resource := range deployment.Resources {
-		foundStorageAccount = foundStorageAccount || resource.Type == "Microsoft.Storage/storageAccounts"
+func getAzureResource(t *testing.T, ctx context.Context, credential azcore.TokenCredential, resourceID string) (int, map[string]any) {
+	t.Helper()
+	token, err := credential.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{"https://management.azure.com/.default"}})
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !foundStorageAccount {
-		t.Error("deployment did not manage a storage account")
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://management.azure.com%s?api-version=2023-05-01", resourceID), nil)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if deployment.Outputs["primaryStorageId"] == nil {
-		t.Error("deployment did not return primaryStorageId")
+	request.Header.Set("Authorization", "Bearer "+token.Token)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
 	}
+	defer response.Body.Close()
+	var body map[string]any
+	if response.StatusCode == http.StatusOK {
+		if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return response.StatusCode, body
 }
 
 func requireEnvironmentVariable(t *testing.T, name string) string {
 	t.Helper()
 	value := os.Getenv(name)
 	if value == "" {
-		t.Skipf("set %s to run the live deployment sample", name)
+		t.Skipf("set %s to run the live deployment samples", name)
 	}
 	return value
 }

--- a/samples/go/snapshot_test.go
+++ b/samples/go/snapshot_test.go
@@ -8,7 +8,85 @@ import (
 	biceptesting "github.com/anthony-c-martin/bicep-testing/packages/go"
 )
 
-func TestInfrastructureHasExpectedResourcesAndNoDiagnostics(t *testing.T) {
+func TestEnvironmentParametersSelectTopologySKUsAndTags(t *testing.T) {
+	session := newSnapshotSession(t)
+	development := takeSnapshot(t, session, "environment-topology/dev.bicepparam")
+	production := takeSnapshot(t, session, "environment-topology/prod.bicepparam")
+
+	if len(development.Diagnostics) != 0 || len(development.PredictedResources) != 1 {
+		t.Fatalf("development snapshot: %d diagnostics, %d resources", len(development.Diagnostics), len(development.PredictedResources))
+	}
+	developmentStorage := development.PredictedResources[0]
+	if developmentStorage.Name != "ordersdevprimary" || nested(developmentStorage.AdditionalProperties, "sku", "name") != "Standard_LRS" {
+		t.Errorf("unexpected development storage: %#v", developmentStorage)
+	}
+	if nested(developmentStorage.AdditionalProperties, "tags", "environment") != "dev" || development.Outputs["auditStorageId"] != nil {
+		t.Error("development tags or conditional audit output did not match")
+	}
+
+	if len(production.PredictedResources) != 2 {
+		t.Fatalf("production resources = %d, want 2", len(production.PredictedResources))
+	}
+	if production.PredictedResources[0].Name != "ordersprodprimary" || production.PredictedResources[1].Name != "ordersprodaudit" {
+		t.Errorf("unexpected production topology: %#v", production.PredictedResources)
+	}
+	if nested(production.PredictedResources[0].AdditionalProperties, "sku", "name") != "Standard_ZRS" ||
+		nested(production.PredictedResources[0].AdditionalProperties, "tags", "dataClassification") != "confidential" ||
+		nested(production.PredictedResources[1].AdditionalProperties, "sku", "name") != "Standard_GRS" {
+		t.Error("production SKUs or tags did not match")
+	}
+}
+
+func TestSecurityBaselineCatchesWeakenedParameters(t *testing.T) {
+	session := newSnapshotSession(t)
+	secure := takeSnapshot(t, session, "security-baseline/secure.bicepparam")
+	insecure := takeSnapshot(t, session, "security-baseline/insecure.bicepparam")
+	secureStorage := resourceByType(t, secure, "Microsoft.Storage/storageAccounts")
+	secureVault := resourceByType(t, secure, "Microsoft.KeyVault/vaults")
+	insecureStorage := resourceByType(t, insecure, "Microsoft.Storage/storageAccounts")
+
+	if secureStorage.Properties["allowBlobPublicAccess"] != false || secureStorage.Properties["allowSharedKeyAccess"] != false ||
+		secureStorage.Properties["minimumTlsVersion"] != "TLS1_2" || secureStorage.Properties["publicNetworkAccess"] != "Disabled" {
+		t.Errorf("storage security baseline not applied: %#v", secureStorage.Properties)
+	}
+	if secureVault.Properties["enablePurgeProtection"] != true || secureVault.Properties["enableRbacAuthorization"] != true ||
+		secureVault.Properties["softDeleteRetentionInDays"] != float64(90) {
+		t.Errorf("vault security baseline not applied: %#v", secureVault.Properties)
+	}
+	if insecureStorage.Properties["minimumTlsVersion"] != "TLS1_0" || insecureStorage.Properties["allowBlobPublicAccess"] != true {
+		t.Error("weakened fixture did not expose the expected regression")
+	}
+}
+
+func TestPrivateNetworkReferencesAreWiredTogether(t *testing.T) {
+	session := newSnapshotSession(t)
+	snapshot := takeSnapshot(t, session, "private-network/main.bicepparam")
+	resources := map[string]biceptesting.SnapshotResource{}
+	for _, resource := range snapshot.PredictedResources {
+		resources[resource.Name] = resource
+	}
+	networkIDs := snapshot.Outputs["networkIds"].(map[string]any)
+	appProperties := resources["orders-vnet/app"].Properties
+	dataProperties := resources["orders-vnet/data"].Properties
+	endpointProperties := resources["orders-storage-pe"].Properties
+	connection := endpointProperties["privateLinkServiceConnections"].([]any)[0].(map[string]any)["properties"].(map[string]any)
+
+	if nested(resources["orders-vnet"].Properties, "addressSpace", "addressPrefixes") == nil || appProperties["addressPrefix"] != "10.42.1.0/24" {
+		t.Error("virtual network address plan did not match")
+	}
+	if nested(appProperties, "networkSecurityGroup", "id") == nil || dataProperties["privateEndpointNetworkPolicies"] != "Disabled" {
+		t.Error("subnet security wiring did not match")
+	}
+	if nested(endpointProperties, "subnet", "id") != networkIDs["dataSubnetId"] || nested(connection, "privateLinkServiceId") == nil {
+		t.Error("private endpoint wiring did not match outputs")
+	}
+	if nested(resources["privatelink.blob.core.windows.net/orders-vnet-link"].Properties, "virtualNetwork", "id") != networkIDs["virtualNetworkId"] {
+		t.Error("private DNS link did not target the virtual network")
+	}
+}
+
+func newSnapshotSession(t *testing.T) *biceptesting.Session {
+	t.Helper()
 	session, err := biceptesting.NewSession(context.Background(), "0.43.1")
 	if err != nil {
 		t.Fatal(err)
@@ -18,36 +96,44 @@ func TestInfrastructureHasExpectedResourcesAndNoDiagnostics(t *testing.T) {
 			t.Errorf("close session: %v", err)
 		}
 	})
+	return session
+}
 
-	parametersPath, err := filepath.Abs(filepath.Join("..", "infra", "main.bicepparam"))
+func takeSnapshot(t *testing.T, session *biceptesting.Session, relativePath string) *biceptesting.SnapshotResult {
+	t.Helper()
+	parametersPath, err := filepath.Abs(filepath.Join("..", "infra", relativePath))
 	if err != nil {
 		t.Fatal(err)
 	}
 	snapshot, err := session.Snapshot(context.Background(), parametersPath, biceptesting.SnapshotMetadata{
-		TenantID:       "00000000-0000-0000-0000-000000000000",
-		SubscriptionID: "00000000-0000-0000-0000-000000000000",
-		ResourceGroup:  "sample-rg",
-		Location:       "eastus",
-		DeploymentName: "sample-deployment",
+		TenantID: "ddbe463a-0554-485d-b589-0b17d60cd38b", SubscriptionID: "28c9069e-23e8-47d2-b640-00d2e0f09616",
+		ResourceGroup: "sample-rg", Location: "eastus", DeploymentName: "sample-deployment",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(snapshot.Diagnostics) != 0 {
-		t.Errorf("got %d diagnostics, want none", len(snapshot.Diagnostics))
-	}
-	if len(snapshot.PredictedResources) != 3 {
-		t.Fatalf("got %d resources, want 3", len(snapshot.PredictedResources))
-	}
+	return snapshot
+}
 
-	wantResources := map[string]string{
-		"sampleprimary": "Microsoft.Storage/storageAccounts",
-		"samplebackup":  "Microsoft.Storage/storageAccounts",
-		"samplekv":      "Microsoft.KeyVault/vaults",
-	}
+func resourceByType(t *testing.T, snapshot *biceptesting.SnapshotResult, resourceType string) biceptesting.SnapshotResource {
+	t.Helper()
 	for _, resource := range snapshot.PredictedResources {
-		if wantType, ok := wantResources[resource.Name]; !ok || resource.Type != wantType {
-			t.Errorf("unexpected resource %q of type %q", resource.Name, resource.Type)
+		if resource.Type == resourceType {
+			return resource
 		}
 	}
+	t.Fatalf("resource type %s not found", resourceType)
+	return biceptesting.SnapshotResource{}
+}
+
+func nested(value map[string]any, keys ...string) any {
+	var current any = value
+	for _, key := range keys {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return nil
+		}
+		current = object[key]
+	}
+	return current
 }

--- a/samples/infra/environment-topology/dev.bicepparam
+++ b/samples/infra/environment-topology/dev.bicepparam
@@ -1,0 +1,5 @@
+using 'main.bicep'
+
+param workloadName = 'orders'
+param environmentName = 'dev'
+param location = 'eastus'

--- a/samples/infra/environment-topology/main.bicep
+++ b/samples/infra/environment-topology/main.bicep
@@ -1,0 +1,48 @@
+@description('Short lowercase name for the workload.')
+param workloadName string
+
+@description('Deployment environment represented by this topology.')
+param environmentName 'dev' | 'prod'
+
+@description('Azure region used by all resources.')
+param location string = resourceGroup().location
+
+var isProduction = environmentName == 'prod'
+var commonTags = {
+  environment: environmentName
+  workload: workloadName
+  dataClassification: isProduction ? 'confidential' : 'internal'
+}
+
+resource primaryStorage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: '${workloadName}${environmentName}primary'
+  location: location
+  tags: commonTags
+  sku: {
+    name: isProduction ? 'Standard_ZRS' : 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+resource auditStorage 'Microsoft.Storage/storageAccounts@2023-05-01' = if (isProduction) {
+  name: '${workloadName}${environmentName}audit'
+  location: location
+  tags: commonTags
+  sku: {
+    name: 'Standard_GRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+output primaryStorageId string = primaryStorage.id
+output auditStorageId string? = isProduction ? auditStorage.id : null

--- a/samples/infra/environment-topology/prod.bicepparam
+++ b/samples/infra/environment-topology/prod.bicepparam
@@ -1,0 +1,5 @@
+using 'main.bicep'
+
+param workloadName = 'orders'
+param environmentName = 'prod'
+param location = 'eastus'

--- a/samples/infra/live-storage/main.bicep
+++ b/samples/infra/live-storage/main.bicep
@@ -1,0 +1,54 @@
+@description('Unique lowercase alphanumeric prefix for globally named test resources.')
+param resourcePrefix string
+
+@description('Azure region used by all resources.')
+param location string = resourceGroup().location
+
+@description('Creates an additional account used to demonstrate stack reconciliation.')
+param includeAuditStorage bool = false
+
+var shortPrefix = take(toLower(resourcePrefix), 8)
+var nameSuffix = uniqueString(resourcePrefix, resourceGroup().id)
+
+resource primaryStorage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: '${shortPrefix}pri${nameSuffix}'
+  location: location
+  tags: {
+    purpose: 'bicep-testing-sample'
+  }
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    publicNetworkAccess: 'Disabled'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+resource auditStorage 'Microsoft.Storage/storageAccounts@2023-05-01' = if (includeAuditStorage) {
+  name: '${shortPrefix}aud${nameSuffix}'
+  location: location
+  tags: {
+    purpose: 'bicep-testing-sample'
+  }
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    publicNetworkAccess: 'Disabled'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+output primaryStorageId string = primaryStorage.id
+output primaryStorageName string = primaryStorage.name
+output primaryBlobEndpoint string = primaryStorage.properties.primaryEndpoints.blob
+output auditStorageId string? = includeAuditStorage ? auditStorage.id : null

--- a/samples/infra/live-storage/main.bicepparam
+++ b/samples/infra/live-storage/main.bicepparam
@@ -1,0 +1,5 @@
+using 'main.bicep'
+
+param resourcePrefix = 'sample'
+param location = 'eastus'
+param includeAuditStorage = false

--- a/samples/infra/private-network/main.bicep
+++ b/samples/infra/private-network/main.bicep
@@ -1,0 +1,128 @@
+@description('Short lowercase prefix used to name resources.')
+param resourcePrefix string
+
+@description('Azure region used by all resources.')
+param location string = resourceGroup().location
+
+@description('Private DNS zone for the storage blob endpoint in the target cloud.')
+param blobPrivateDnsZoneName string
+
+resource appNsg 'Microsoft.Network/networkSecurityGroups@2023-11-01' = {
+  name: '${resourcePrefix}-app-nsg'
+  location: location
+}
+
+resource dataNsg 'Microsoft.Network/networkSecurityGroups@2023-11-01' = {
+  name: '${resourcePrefix}-data-nsg'
+  location: location
+}
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' = {
+  name: '${resourcePrefix}-vnet'
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.42.0.0/16'
+      ]
+    }
+  }
+}
+
+resource appSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = {
+  parent: virtualNetwork
+  name: 'app'
+  properties: {
+    addressPrefix: '10.42.1.0/24'
+    networkSecurityGroup: {
+      id: appNsg.id
+    }
+  }
+}
+
+resource dataSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = {
+  parent: virtualNetwork
+  name: 'data'
+  properties: {
+    addressPrefix: '10.42.2.0/24'
+    networkSecurityGroup: {
+      id: dataNsg.id
+    }
+    privateEndpointNetworkPolicies: 'Disabled'
+  }
+}
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: '${resourcePrefix}privatestore'
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    publicNetworkAccess: 'Disabled'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: blobPrivateDnsZoneName
+  location: 'global'
+}
+
+resource dnsLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: privateDnsZone
+  name: '${resourcePrefix}-vnet-link'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: virtualNetwork.id
+    }
+  }
+}
+
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
+  name: '${resourcePrefix}-storage-pe'
+  location: location
+  properties: {
+    privateLinkServiceConnections: [
+      {
+        name: 'blob'
+        properties: {
+          groupIds: [
+            'blob'
+          ]
+          privateLinkServiceId: storage.id
+        }
+      }
+    ]
+    subnet: {
+      id: dataSubnet.id
+    }
+  }
+}
+
+resource dnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = {
+  parent: privateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'blob'
+        properties: {
+          privateDnsZoneId: privateDnsZone.id
+        }
+      }
+    ]
+  }
+}
+
+output networkIds object = {
+  appSubnetId: appSubnet.id
+  dataSubnetId: dataSubnet.id
+  privateEndpointId: privateEndpoint.id
+  virtualNetworkId: virtualNetwork.id
+}

--- a/samples/infra/private-network/main.bicepparam
+++ b/samples/infra/private-network/main.bicepparam
@@ -1,0 +1,5 @@
+using 'main.bicep'
+
+param resourcePrefix = 'orders'
+param location = 'eastus'
+param blobPrivateDnsZoneName = 'privatelink.blob.core.windows.net'

--- a/samples/infra/security-baseline/insecure.bicepparam
+++ b/samples/infra/security-baseline/insecure.bicepparam
@@ -1,0 +1,5 @@
+using 'main.bicep'
+
+param resourcePrefix = 'orders'
+param location = 'eastus'
+param enforceSecurity = false

--- a/samples/infra/security-baseline/main.bicep
+++ b/samples/infra/security-baseline/main.bicep
@@ -1,0 +1,44 @@
+@description('Short lowercase prefix used to name resources.')
+param resourcePrefix string
+
+@description('Azure region used by all resources.')
+param location string = resourceGroup().location
+
+@description('Enables the security baseline. False is used only to demonstrate regression detection.')
+param enforceSecurity bool = true
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: '${resourcePrefix}securestore'
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    allowBlobPublicAccess: !enforceSecurity
+    allowSharedKeyAccess: !enforceSecurity
+    minimumTlsVersion: enforceSecurity ? 'TLS1_2' : 'TLS1_0'
+    publicNetworkAccess: enforceSecurity ? 'Disabled' : 'Enabled'
+    supportsHttpsTrafficOnly: enforceSecurity
+  }
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: '${resourcePrefix}-secure-kv'
+  location: location
+  properties: {
+    enablePurgeProtection: enforceSecurity
+    enableRbacAuthorization: enforceSecurity
+    enableSoftDelete: true
+    publicNetworkAccess: enforceSecurity ? 'Disabled' : 'Enabled'
+    softDeleteRetentionInDays: enforceSecurity ? 90 : 7
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: tenant().tenantId
+  }
+}
+
+output storageId string = storage.id
+output keyVaultId string = keyVault.id

--- a/samples/infra/security-baseline/secure.bicepparam
+++ b/samples/infra/security-baseline/secure.bicepparam
@@ -1,0 +1,5 @@
+using 'main.bicep'
+
+param resourcePrefix = 'orders'
+param location = 'eastus'
+param enforceSecurity = true

--- a/samples/node/deployment.test.js
+++ b/samples/node/deployment.test.js
@@ -7,30 +7,80 @@ const resourceGroup = process.env.AZURE_RESOURCE_GROUP;
 const stackName = process.env.BICEP_TEST_STACK_NAME;
 const resourcePrefix = process.env.BICEP_TEST_RESOURCE_PREFIX;
 const liveDescribe = subscriptionId && resourceGroup && stackName && resourcePrefix
-  && process.env.BICEP_TEST_VALIDATE_ONLY !== '1'
-  ? describe
-  : describe.skip;
+  && process.env.BICEP_TEST_VALIDATE_ONLY !== '1' ? describe : describe.skip;
+const parametersPath = path.resolve(__dirname, '../infra/live-storage/main.bicepparam');
 
-liveDescribe('Bicep infrastructure deployment', () => {
-  test('deploys resources and removes them afterward', async () => {
+async function getAzureResource(credential, resourceId) {
+  const token = await credential.getToken('https://management.azure.com/.default');
+  return fetch(`https://management.azure.com${resourceId}?api-version=2023-05-01`, {
+    headers: { Authorization: `Bearer ${token.token}` },
+  });
+}
+
+liveDescribe('real-world Bicep deployments', () => {
+  test('deploys secure storage, verifies Azure state, and cleans it up', async () => {
+    const credential = new DefaultAzureCredential();
     const session = await BicepTestSession.create('0.43.1');
     let deployment;
+    let primaryStorageId;
     try {
-      deployment = await session.deploy(new DefaultAzureCredential(), {
-        filePath: path.resolve(__dirname, '../infra/main.bicepparam'),
+      deployment = await session.deploy(credential, {
+        filePath: parametersPath,
         subscriptionId,
         resourceGroup,
-        stackName,
-        parameterOverrides: { env: resourcePrefix },
+        stackName: `${stackName}-secure`,
+        parameterOverrides: { resourcePrefix, includeAuditStorage: false },
       });
-
-      expect(deployment.resources).toEqual(expect.arrayContaining([
-        expect.objectContaining({ type: 'Microsoft.Storage/storageAccounts' }),
-      ]));
-      expect(deployment.outputs.primaryStorageId).toContain('/providers/Microsoft.Storage/storageAccounts/');
+      primaryStorageId = deployment.outputs.primaryStorageId;
+      const response = await getAzureResource(credential, primaryStorageId);
+      expect(response.ok).toBe(true);
+      const storage = await response.json();
+      expect(storage.properties).toEqual(expect.objectContaining({
+        allowBlobPublicAccess: false,
+        allowSharedKeyAccess: false,
+        minimumTlsVersion: 'TLS1_2',
+        publicNetworkAccess: 'Disabled',
+        supportsHttpsTrafficOnly: true,
+      }));
+      expect(deployment.resources.map(resource => resource.id)).toContain(primaryStorageId);
     } finally {
       await deployment?.teardown();
       session.dispose();
     }
+    expect((await getAzureResource(credential, primaryStorageId)).status).toBe(404);
   }, 15 * 60_000);
+
+  test('reconciles a removed audit account and tears down remaining resources', async () => {
+    const credential = new DefaultAzureCredential();
+    const session = await BicepTestSession.create('0.43.1');
+    let reconciled;
+    let primaryStorageId;
+    let auditStorageId;
+    try {
+      const initial = await session.deploy(credential, {
+        filePath: parametersPath,
+        subscriptionId,
+        resourceGroup,
+        stackName,
+        parameterOverrides: { resourcePrefix, includeAuditStorage: true },
+      });
+      primaryStorageId = initial.outputs.primaryStorageId;
+      auditStorageId = initial.outputs.auditStorageId;
+      expect(initial.resources).toHaveLength(2);
+
+      reconciled = await session.deploy(credential, {
+        filePath: parametersPath,
+        subscriptionId,
+        resourceGroup,
+        stackName,
+        parameterOverrides: { resourcePrefix, includeAuditStorage: false },
+      });
+      expect(reconciled.resources.map(resource => resource.id)).toEqual([primaryStorageId]);
+      expect((await getAzureResource(credential, auditStorageId)).status).toBe(404);
+    } finally {
+      await reconciled?.teardown();
+      session.dispose();
+    }
+    expect((await getAzureResource(credential, primaryStorageId)).status).toBe(404);
+  }, 20 * 60_000);
 });

--- a/samples/node/snapshot.test.js
+++ b/samples/node/snapshot.test.js
@@ -2,34 +2,100 @@ const path = require('node:path');
 const { BicepTestSession } = require('@anthony-c-martin/bicep-testing');
 
 const sampleDescribe = process.env.BICEP_TEST_VALIDATE_ONLY === '1' ? describe.skip : describe;
+const metadata = [
+  'ddbe463a-0554-485d-b589-0b17d60cd38b',
+  '28c9069e-23e8-47d2-b640-00d2e0f09616',
+  'sample-rg',
+  'eastus',
+  'sample-deployment',
+];
 
-sampleDescribe('Bicep infrastructure snapshot', () => {
+sampleDescribe('real-world Bicep snapshots', () => {
   let session;
-  let snapshot;
 
   beforeAll(async () => {
     session = await BicepTestSession.create('0.43.1');
-    snapshot = await session.snapshot(
-      path.resolve(__dirname, '../infra/main.bicepparam'),
-      '00000000-0000-0000-0000-000000000000',
-      '00000000-0000-0000-0000-000000000000',
-      'sample-rg',
-      'eastus',
-      'sample-deployment',
-    );
   }, 60_000);
 
   afterAll(() => session.dispose());
 
-  test('predicts the expected resources without diagnostics', () => {
-    expect(snapshot.diagnostics).toHaveLength(0);
-    expect(snapshot.predictedResources).toHaveLength(3);
-    expect(snapshot.predictedResources).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ type: 'Microsoft.Storage/storageAccounts', name: 'sampleprimary' }),
-        expect.objectContaining({ type: 'Microsoft.Storage/storageAccounts', name: 'samplebackup' }),
-        expect.objectContaining({ type: 'Microsoft.KeyVault/vaults', name: 'samplekv' }),
-      ]),
-    );
+  async function snapshot(relativePath) {
+    return session.snapshot(path.resolve(__dirname, '../infra', relativePath), ...metadata);
+  }
+
+  test('environment parameters select the expected topology, SKUs, and tags', async () => {
+    const development = await snapshot('environment-topology/dev.bicepparam');
+    const production = await snapshot('environment-topology/prod.bicepparam');
+
+    expect(development.diagnostics).toHaveLength(0);
+    expect(development.predictedResources).toEqual([
+      expect.objectContaining({
+        name: 'ordersdevprimary',
+        sku: { name: 'Standard_LRS' },
+        tags: expect.objectContaining({ environment: 'dev', dataClassification: 'internal' }),
+      }),
+    ]);
+    expect(development.outputs.auditStorageId).toBeNull();
+
+    expect(production.diagnostics).toHaveLength(0);
+    expect(production.predictedResources.map(resource => resource.name)).toEqual([
+      'ordersprodprimary',
+      'ordersprodaudit',
+    ]);
+    expect(production.predictedResources[0]).toEqual(expect.objectContaining({
+      sku: { name: 'Standard_ZRS' },
+      tags: expect.objectContaining({ environment: 'prod', dataClassification: 'confidential' }),
+    }));
+    expect(production.predictedResources[1].sku.name).toBe('Standard_GRS');
+    expect(production.outputs.auditStorageId).toContain('/storageAccounts/ordersprodaudit');
+  });
+
+  test('the security baseline catches a deliberately weakened parameter set', async () => {
+    const secure = await snapshot('security-baseline/secure.bicepparam');
+    const insecure = await snapshot('security-baseline/insecure.bicepparam');
+    const secureStorage = secure.predictedResources.find(resource => resource.type === 'Microsoft.Storage/storageAccounts');
+    const secureVault = secure.predictedResources.find(resource => resource.type === 'Microsoft.KeyVault/vaults');
+    const insecureStorage = insecure.predictedResources.find(resource => resource.type === 'Microsoft.Storage/storageAccounts');
+
+    expect(secure.diagnostics).toHaveLength(0);
+    expect(secureStorage.properties).toEqual(expect.objectContaining({
+      allowBlobPublicAccess: false,
+      allowSharedKeyAccess: false,
+      minimumTlsVersion: 'TLS1_2',
+      publicNetworkAccess: 'Disabled',
+      supportsHttpsTrafficOnly: true,
+    }));
+    expect(secureVault.properties).toEqual(expect.objectContaining({
+      enablePurgeProtection: true,
+      enableRbacAuthorization: true,
+      publicNetworkAccess: 'Disabled',
+      softDeleteRetentionInDays: 90,
+    }));
+    expect(insecureStorage.properties.minimumTlsVersion).toBe('TLS1_0');
+    expect(insecureStorage.properties.allowBlobPublicAccess).toBe(true);
+  });
+
+  test('private endpoint, subnet, NSG, and DNS references are wired together', async () => {
+    const result = await snapshot('private-network/main.bicepparam');
+    const resources = Object.fromEntries(result.predictedResources.map(resource => [resource.name, resource]));
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(resources['orders-vnet'].properties.addressSpace.addressPrefixes).toEqual(['10.42.0.0/16']);
+    expect(resources['orders-vnet/app'].properties).toEqual(expect.objectContaining({
+      addressPrefix: '10.42.1.0/24',
+      networkSecurityGroup: expect.objectContaining({ id: expect.stringContaining('/orders-app-nsg') }),
+    }));
+    expect(resources['orders-vnet/data'].properties).toEqual(expect.objectContaining({
+      addressPrefix: '10.42.2.0/24',
+      privateEndpointNetworkPolicies: 'Disabled',
+      networkSecurityGroup: expect.objectContaining({ id: expect.stringContaining('/orders-data-nsg') }),
+    }));
+    expect(resources['orders-storage-pe'].properties.subnet.id).toBe(result.outputs.networkIds.dataSubnetId);
+    expect(resources['orders-storage-pe'].properties.privateLinkServiceConnections[0].properties).toEqual(expect.objectContaining({
+      groupIds: ['blob'],
+      privateLinkServiceId: expect.stringContaining('/storageAccounts/ordersprivatestore'),
+    }));
+    expect(resources['privatelink.blob.core.windows.net/orders-vnet-link'].properties.virtualNetwork.id)
+      .toBe(result.outputs.networkIds.virtualNetworkId);
   });
 });

--- a/samples/powershell/BicepTest.Deployment.Sample.Tests.ps1
+++ b/samples/powershell/BicepTest.Deployment.Sample.Tests.ps1
@@ -1,28 +1,62 @@
 BeforeAll {
-    $parametersPath = Join-Path $PSScriptRoot '../infra/main.bicepparam'
+    $parametersPath = Join-Path $PSScriptRoot '../infra/live-storage/main.bicepparam'
     Import-Module AnthonyCMartin.BicepTesting -RequiredVersion 0.1.0 -Force
+
+    function Get-AzureResourceResponse($Credential, [string] $ResourceId) {
+        $tokenContext = [Azure.Core.TokenRequestContext]::new(
+            [string[]] @('https://management.azure.com/.default'))
+        $token = $Credential.GetToken($tokenContext, [Threading.CancellationToken]::None)
+        Invoke-WebRequest `
+            -Uri "https://management.azure.com${ResourceId}?api-version=2023-05-01" `
+            -Headers @{ Authorization = "Bearer $($token.Token)" } `
+            -SkipHttpErrorCheck
+    }
+
+    function Start-SampleDeployment(
+        $Session,
+        $Credential,
+        [string] $StackName,
+        [bool] $IncludeAuditStorage
+    ) {
+        $Session | Start-BicepTestDeployment `
+            -Credential $Credential `
+            -Path $parametersPath `
+            -SubscriptionId $env:AZURE_SUBSCRIPTION_ID `
+            -ResourceGroup $env:AZURE_RESOURCE_GROUP `
+            -StackName $StackName `
+            -ParameterOverrides @{
+                resourcePrefix = $env:BICEP_TEST_RESOURCE_PREFIX
+                includeAuditStorage = $IncludeAuditStorage
+            }
+    }
 }
 
-Describe 'Bicep infrastructure deployment' -Skip:(
+Describe 'Real-world Bicep deployments' -Skip:(
     -not $env:AZURE_SUBSCRIPTION_ID -or
     -not $env:AZURE_RESOURCE_GROUP -or
     -not $env:BICEP_TEST_STACK_NAME -or
     -not $env:BICEP_TEST_RESOURCE_PREFIX) {
-    It 'deploys resources and removes them afterward' {
+    It 'verifies secure storage in Azure and removes it afterward' {
+        $credential = [Azure.Identity.DefaultAzureCredential]::new()
         $session = New-BicepTestSession -BicepVersion '0.43.1'
+        $deployment = $null
         try {
-            $credential = [Azure.Identity.DefaultAzureCredential]::new()
-            $deployment = $session | Start-BicepTestDeployment `
+            $deployment = Start-SampleDeployment `
+                -Session $session `
                 -Credential $credential `
-                -Path $parametersPath `
-                -SubscriptionId $env:AZURE_SUBSCRIPTION_ID `
-                -ResourceGroup $env:AZURE_RESOURCE_GROUP `
-                -StackName $env:BICEP_TEST_STACK_NAME `
-                -ParameterOverrides @{ env = $env:BICEP_TEST_RESOURCE_PREFIX }
+                -StackName "$env:BICEP_TEST_STACK_NAME-secure" `
+                -IncludeAuditStorage $false
+            $primaryStorageId = $deployment.Outputs['primaryStorageId'].GetString()
+            $response = Get-AzureResourceResponse $credential $primaryStorageId
+            $storage = $response.Content | ConvertFrom-Json
 
-            $deployment.Resources.Type | Should -Contain 'Microsoft.Storage/storageAccounts'
-            $deployment.Outputs['primaryStorageId'].GetString() |
-                Should -Match '/providers/Microsoft.Storage/storageAccounts/'
+            $response.StatusCode | Should -Be 200
+            $storage.properties.allowBlobPublicAccess | Should -BeFalse
+            $storage.properties.allowSharedKeyAccess | Should -BeFalse
+            $storage.properties.minimumTlsVersion | Should -Be 'TLS1_2'
+            $storage.properties.publicNetworkAccess | Should -Be 'Disabled'
+            $storage.properties.supportsHttpsTrafficOnly | Should -BeTrue
+            $deployment.Resources.Id | Should -Contain $primaryStorageId
         }
         finally {
             if ($deployment) {
@@ -30,5 +64,40 @@ Describe 'Bicep infrastructure deployment' -Skip:(
             }
             $session | Remove-BicepTestSession
         }
+
+        (Get-AzureResourceResponse $credential $primaryStorageId).StatusCode | Should -Be 404
+    }
+
+    It 'reconciles removed audit storage and cleans up remaining resources' {
+        $credential = [Azure.Identity.DefaultAzureCredential]::new()
+        $session = New-BicepTestSession -BicepVersion '0.43.1'
+        $reconciled = $null
+        try {
+            $initial = Start-SampleDeployment `
+                -Session $session `
+                -Credential $credential `
+                -StackName $env:BICEP_TEST_STACK_NAME `
+                -IncludeAuditStorage $true
+            $primaryStorageId = $initial.Outputs['primaryStorageId'].GetString()
+            $auditStorageId = $initial.Outputs['auditStorageId'].GetString()
+            $initial.Resources | Should -HaveCount 2
+
+            $reconciled = Start-SampleDeployment `
+                -Session $session `
+                -Credential $credential `
+                -StackName $env:BICEP_TEST_STACK_NAME `
+                -IncludeAuditStorage $false
+            $reconciled.Resources | Should -HaveCount 1
+            $reconciled.Resources[0].Id | Should -Be $primaryStorageId
+            (Get-AzureResourceResponse $credential $auditStorageId).StatusCode | Should -Be 404
+        }
+        finally {
+            if ($reconciled) {
+                $reconciled | Remove-BicepTestDeployment
+            }
+            $session | Remove-BicepTestSession
+        }
+
+        (Get-AzureResourceResponse $credential $primaryStorageId).StatusCode | Should -Be 404
     }
 }

--- a/samples/powershell/BicepTest.Sample.Tests.ps1
+++ b/samples/powershell/BicepTest.Sample.Tests.ps1
@@ -1,27 +1,74 @@
 BeforeAll {
-    $parametersPath = Join-Path $PSScriptRoot '../infra/main.bicepparam'
+    $infraPath = Join-Path $PSScriptRoot '../infra'
     Import-Module AnthonyCMartin.BicepTesting -RequiredVersion 0.1.0 -Force
-
     $session = New-BicepTestSession -BicepVersion '0.43.1'
-    $snapshot = $session | Get-BicepSnapshot `
-        -Path $parametersPath `
-        -TenantId '00000000-0000-0000-0000-000000000000' `
-        -SubscriptionId '00000000-0000-0000-0000-000000000000' `
-        -ResourceGroup 'sample-rg' `
-        -Location 'eastus' `
-        -DeploymentName 'sample-deployment'
+
+    function Get-SampleSnapshot([string] $RelativePath) {
+        $session | Get-BicepSnapshot `
+            -Path (Join-Path $infraPath $RelativePath) `
+            -TenantId 'ddbe463a-0554-485d-b589-0b17d60cd38b' `
+            -SubscriptionId '28c9069e-23e8-47d2-b640-00d2e0f09616' `
+            -ResourceGroup 'sample-rg' `
+            -Location 'eastus' `
+            -DeploymentName 'sample-deployment'
+    }
 }
 
 AfterAll {
     $session | Remove-BicepTestSession
 }
 
-Describe 'Bicep infrastructure' {
-    It 'has the expected resources and no diagnostics' {
-        $snapshot.Diagnostics | Should -BeNullOrEmpty
-        $snapshot.PredictedResources | Should -HaveCount 3
-        $snapshot.PredictedResources.Name | Should -Contain 'sampleprimary'
-        $snapshot.PredictedResources.Name | Should -Contain 'samplebackup'
-        $snapshot.PredictedResources.Name | Should -Contain 'samplekv'
+Describe 'Real-world Bicep snapshots' {
+    It 'selects environment topology, SKUs, and tags' {
+        $development = Get-SampleSnapshot 'environment-topology/dev.bicepparam'
+        $production = Get-SampleSnapshot 'environment-topology/prod.bicepparam'
+
+        $development.Diagnostics | Should -BeNullOrEmpty
+        $development.PredictedResources | Should -HaveCount 1
+        $development.PredictedResources[0].Name | Should -Be 'ordersdevprimary'
+        $development.PredictedResources[0].AdditionalProperties['sku'].GetProperty('name').GetString() | Should -Be 'Standard_LRS'
+        $development.PredictedResources[0].AdditionalProperties['tags'].GetProperty('environment').GetString() | Should -Be 'dev'
+        $development.Outputs.auditStorageId | Should -BeNullOrEmpty
+        $production.PredictedResources.Name | Should -Be @('ordersprodprimary', 'ordersprodaudit')
+        $production.PredictedResources[0].AdditionalProperties['sku'].GetProperty('name').GetString() | Should -Be 'Standard_ZRS'
+        $production.PredictedResources[0].AdditionalProperties['tags'].GetProperty('dataClassification').GetString() | Should -Be 'confidential'
+        $production.PredictedResources[1].AdditionalProperties['sku'].GetProperty('name').GetString() | Should -Be 'Standard_GRS'
+    }
+
+    It 'catches a deliberately weakened security baseline' {
+        $secure = Get-SampleSnapshot 'security-baseline/secure.bicepparam'
+        $insecure = Get-SampleSnapshot 'security-baseline/insecure.bicepparam'
+        $secureStorage = $secure.PredictedResources | Where-Object Type -eq 'Microsoft.Storage/storageAccounts'
+        $secureVault = $secure.PredictedResources | Where-Object Type -eq 'Microsoft.KeyVault/vaults'
+        $insecureStorage = $insecure.PredictedResources | Where-Object Type -eq 'Microsoft.Storage/storageAccounts'
+
+        $secureStorage.Properties.GetProperty('allowBlobPublicAccess').GetBoolean() | Should -BeFalse
+        $secureStorage.Properties.GetProperty('allowSharedKeyAccess').GetBoolean() | Should -BeFalse
+        $secureStorage.Properties.GetProperty('minimumTlsVersion').GetString() | Should -Be 'TLS1_2'
+        $secureStorage.Properties.GetProperty('publicNetworkAccess').GetString() | Should -Be 'Disabled'
+        $secureVault.Properties.GetProperty('enablePurgeProtection').GetBoolean() | Should -BeTrue
+        $secureVault.Properties.GetProperty('enableRbacAuthorization').GetBoolean() | Should -BeTrue
+        $secureVault.Properties.GetProperty('softDeleteRetentionInDays').GetInt32() | Should -Be 90
+        $insecureStorage.Properties.GetProperty('minimumTlsVersion').GetString() | Should -Be 'TLS1_0'
+        $insecureStorage.Properties.GetProperty('allowBlobPublicAccess').GetBoolean() | Should -BeTrue
+    }
+
+    It 'wires private endpoint, subnet, NSG, and DNS references together' {
+        $snapshot = Get-SampleSnapshot 'private-network/main.bicepparam'
+        $resources = @{}
+        $snapshot.PredictedResources | ForEach-Object { $resources[$_.Name] = $_ }
+
+        $networkIds = $snapshot.Outputs['networkIds']
+        $resources['orders-vnet'].Properties.GetProperty('addressSpace').GetProperty('addressPrefixes')[0].GetString() | Should -Be '10.42.0.0/16'
+        $resources['orders-vnet/app'].Properties.GetProperty('addressPrefix').GetString() | Should -Be '10.42.1.0/24'
+        $resources['orders-vnet/app'].Properties.GetProperty('networkSecurityGroup').GetProperty('id').GetString() | Should -Match '/orders-app-nsg$'
+        $resources['orders-vnet/data'].Properties.GetProperty('privateEndpointNetworkPolicies').GetString() | Should -Be 'Disabled'
+        $resources['orders-storage-pe'].Properties.GetProperty('subnet').GetProperty('id').GetString() |
+            Should -Be $networkIds.GetProperty('dataSubnetId').GetString()
+        $connection = $resources['orders-storage-pe'].Properties.GetProperty('privateLinkServiceConnections')[0].GetProperty('properties')
+        $connection.GetProperty('groupIds')[0].GetString() | Should -Be 'blob'
+        $connection.GetProperty('privateLinkServiceId').GetString() | Should -Match '/storageAccounts/ordersprivatestore$'
+        $resources['privatelink.blob.core.windows.net/orders-vnet-link'].Properties.GetProperty('virtualNetwork').GetProperty('id').GetString() |
+            Should -Be $networkIds.GetProperty('virtualNetworkId').GetString()
     }
 }

--- a/samples/python/test_deployment.py
+++ b/samples/python/test_deployment.py
@@ -1,36 +1,108 @@
+import json
 import os
 from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
 
 import pytest
-from azure.identity import DefaultAzureCredential
 from anthonycmartin.bicep_testing import BicepTestSession
+from azure.identity import DefaultAzureCredential
 
 
 def require_environment_variable(name: str) -> str:
     value = os.getenv(name)
     if not value:
-        pytest.skip(f"set {name} to run the live deployment sample")
+        pytest.skip(f"set {name} to run the live deployment samples")
     return value
 
 
-def test_infrastructure_deploys_and_is_removed_afterward() -> None:
-    subscription_id = require_environment_variable("AZURE_SUBSCRIPTION_ID")
-    resource_group = require_environment_variable("AZURE_RESOURCE_GROUP")
-    stack_name = require_environment_variable("BICEP_TEST_STACK_NAME")
-    resource_prefix = require_environment_variable("BICEP_TEST_RESOURCE_PREFIX")
-    parameters = Path(__file__).parents[1] / "infra" / "main.bicepparam"
+def live_settings() -> tuple[str, str, str, str]:
+    return (
+        require_environment_variable("AZURE_SUBSCRIPTION_ID"),
+        require_environment_variable("AZURE_RESOURCE_GROUP"),
+        require_environment_variable("BICEP_TEST_STACK_NAME"),
+        require_environment_variable("BICEP_TEST_RESOURCE_PREFIX"),
+    )
+
+
+def get_azure_resource(credential: DefaultAzureCredential, resource_id: str) -> tuple[int, dict[str, Any] | None]:
+    token = credential.get_token("https://management.azure.com/.default")
+    request = Request(
+        f"https://management.azure.com{resource_id}?api-version=2023-05-01",
+        headers={"Authorization": f"Bearer {token.token}"},
+    )
+    try:
+        with urlopen(request) as response:
+            return response.status, json.load(response)
+    except HTTPError as error:
+        return error.code, None
+
+
+def test_secure_storage_is_verified_in_azure_and_removed() -> None:
+    subscription_id, resource_group, stack_name, resource_prefix = live_settings()
+    parameters = Path(__file__).parents[1] / "infra" / "live-storage" / "main.bicepparam"
+    credential = DefaultAzureCredential()
+    primary_storage_id = ""
 
     with BicepTestSession.create("0.43.1") as session:
-        with session.deploy(
-            DefaultAzureCredential(),
+        deployment = session.deploy(
+            credential,
+            parameters,
+            subscription_id,
+            resource_group,
+            f"{stack_name}-secure",
+            {"resourcePrefix": resource_prefix, "includeAuditStorage": False},
+        )
+        try:
+            primary_storage_id = deployment.outputs["primaryStorageId"]
+            status, storage = get_azure_resource(credential, primary_storage_id)
+            assert status == 200
+            assert storage is not None
+            assert storage["properties"]["allowBlobPublicAccess"] is False
+            assert storage["properties"]["allowSharedKeyAccess"] is False
+            assert storage["properties"]["minimumTlsVersion"] == "TLS1_2"
+            assert storage["properties"]["publicNetworkAccess"] == "Disabled"
+            assert storage["properties"]["supportsHttpsTrafficOnly"] is True
+            assert primary_storage_id in {resource.id for resource in deployment.resources}
+        finally:
+            deployment.close()
+
+    assert get_azure_resource(credential, primary_storage_id)[0] == 404
+
+
+def test_deployment_reconciles_removed_audit_storage_and_cleans_up() -> None:
+    subscription_id, resource_group, stack_name, resource_prefix = live_settings()
+    parameters = Path(__file__).parents[1] / "infra" / "live-storage" / "main.bicepparam"
+    credential = DefaultAzureCredential()
+    primary_storage_id = ""
+    audit_storage_id = ""
+
+    with BicepTestSession.create("0.43.1") as session:
+        initial = session.deploy(
+            credential,
             parameters,
             subscription_id,
             resource_group,
             stack_name,
-            {"env": resource_prefix},
-        ) as deployment:
-            assert any(
-                resource.type == "Microsoft.Storage/storageAccounts"
-                for resource in deployment.resources
-            )
-            assert "/providers/Microsoft.Storage/storageAccounts/" in deployment.outputs["primaryStorageId"]
+            {"resourcePrefix": resource_prefix, "includeAuditStorage": True},
+        )
+        primary_storage_id = initial.outputs["primaryStorageId"]
+        audit_storage_id = initial.outputs["auditStorageId"]
+        assert len(initial.resources) == 2
+
+        reconciled = session.deploy(
+            credential,
+            parameters,
+            subscription_id,
+            resource_group,
+            stack_name,
+            {"resourcePrefix": resource_prefix, "includeAuditStorage": False},
+        )
+        try:
+            assert [resource.id for resource in reconciled.resources] == [primary_storage_id]
+            assert get_azure_resource(credential, audit_storage_id)[0] == 404
+        finally:
+            reconciled.close()
+
+    assert get_azure_resource(credential, primary_storage_id)[0] == 404

--- a/samples/python/test_snapshot.py
+++ b/samples/python/test_snapshot.py
@@ -1,24 +1,84 @@
 from pathlib import Path
+from typing import Any
 
 from anthonycmartin.bicep_testing import BicepTestSession, SnapshotMetadata
 
 
-def test_infrastructure_snapshot() -> None:
-    parameters = Path(__file__).parents[1] / "infra" / "main.bicepparam"
+def snapshot(relative_path: str):
+    parameters = Path(__file__).parents[1] / "infra" / relative_path
     metadata = SnapshotMetadata(
-        tenant_id="00000000-0000-0000-0000-000000000000",
-        subscription_id="00000000-0000-0000-0000-000000000000",
+        tenant_id="ddbe463a-0554-485d-b589-0b17d60cd38b",
+        subscription_id="28c9069e-23e8-47d2-b640-00d2e0f09616",
         resource_group="sample-rg",
         location="eastus",
         deployment_name="sample-deployment",
     )
-
     with BicepTestSession.create("0.43.1") as session:
-        snapshot = session.snapshot(parameters, metadata)
+        return session.snapshot(parameters, metadata)
 
-    assert snapshot.diagnostics == ()
-    assert {resource.name for resource in snapshot.predicted_resources} == {
-        "sampleprimary",
-        "samplebackup",
-        "samplekv",
-    }
+
+def resource_by_type(result, resource_type: str):
+    return next(resource for resource in result.predicted_resources if resource.type == resource_type)
+
+
+def nested(value: dict[str, Any], *keys: str) -> Any:
+    current: Any = value
+    for key in keys:
+        current = current[key]
+    return current
+
+
+def test_environment_parameters_select_topology_skus_and_tags() -> None:
+    development = snapshot("environment-topology/dev.bicepparam")
+    production = snapshot("environment-topology/prod.bicepparam")
+
+    assert development.diagnostics == ()
+    assert len(development.predicted_resources) == 1
+    development_storage = development.predicted_resources[0]
+    assert development_storage.name == "ordersdevprimary"
+    assert nested(development_storage.additional_properties, "sku", "name") == "Standard_LRS"
+    assert nested(development_storage.additional_properties, "tags", "environment") == "dev"
+    assert development.outputs["auditStorageId"] is None
+
+    assert [resource.name for resource in production.predicted_resources] == [
+        "ordersprodprimary",
+        "ordersprodaudit",
+    ]
+    assert nested(production.predicted_resources[0].additional_properties, "sku", "name") == "Standard_ZRS"
+    assert nested(production.predicted_resources[0].additional_properties, "tags", "dataClassification") == "confidential"
+    assert nested(production.predicted_resources[1].additional_properties, "sku", "name") == "Standard_GRS"
+
+
+def test_security_baseline_catches_weakened_parameters() -> None:
+    secure = snapshot("security-baseline/secure.bicepparam")
+    insecure = snapshot("security-baseline/insecure.bicepparam")
+    secure_storage = resource_by_type(secure, "Microsoft.Storage/storageAccounts")
+    secure_vault = resource_by_type(secure, "Microsoft.KeyVault/vaults")
+    insecure_storage = resource_by_type(insecure, "Microsoft.Storage/storageAccounts")
+
+    assert secure_storage.properties["allowBlobPublicAccess"] is False
+    assert secure_storage.properties["allowSharedKeyAccess"] is False
+    assert secure_storage.properties["minimumTlsVersion"] == "TLS1_2"
+    assert secure_storage.properties["publicNetworkAccess"] == "Disabled"
+    assert secure_vault.properties["enablePurgeProtection"] is True
+    assert secure_vault.properties["enableRbacAuthorization"] is True
+    assert secure_vault.properties["softDeleteRetentionInDays"] == 90
+    assert insecure_storage.properties["minimumTlsVersion"] == "TLS1_0"
+    assert insecure_storage.properties["allowBlobPublicAccess"] is True
+
+
+def test_private_network_references_are_wired_together() -> None:
+    result = snapshot("private-network/main.bicepparam")
+    resources = {resource.name: resource for resource in result.predicted_resources}
+    network_ids = result.outputs["networkIds"]
+
+    assert result.diagnostics == ()
+    assert resources["orders-vnet"].properties["addressSpace"]["addressPrefixes"] == ["10.42.0.0/16"]
+    assert resources["orders-vnet/app"].properties["addressPrefix"] == "10.42.1.0/24"
+    assert resources["orders-vnet/app"].properties["networkSecurityGroup"]["id"].endswith("/orders-app-nsg")
+    assert resources["orders-vnet/data"].properties["privateEndpointNetworkPolicies"] == "Disabled"
+    assert resources["orders-storage-pe"].properties["subnet"]["id"] == network_ids["dataSubnetId"]
+    connection = resources["orders-storage-pe"].properties["privateLinkServiceConnections"][0]["properties"]
+    assert connection["groupIds"] == ["blob"]
+    assert connection["privateLinkServiceId"].endswith("/storageAccounts/ordersprivatestore")
+    assert resources["privatelink.blob.core.windows.net/orders-vnet-link"].properties["virtualNetwork"]["id"] == network_ids["virtualNetworkId"]


### PR DESCRIPTION
## Summary

- add three shared offline scenarios for environment topology, security baselines, and private-network wiring
- add two opt-in live scenarios for secure storage verification and Deployment Stack reconciliation
- implement equivalent native tests across Node, C#, Go, PowerShell, and Python
- use consistent mock tenant and subscription GUIDs in every offline sample
- document the scenario catalog and add a repository-wide LF policy with binary and Windows command-script exceptions

## Validation

- `./scripts/ValidateSamples.ps1`
- all three offline scenarios pass in Jest, MSTest, Go `testing`, Pester, and pytest
- live tests compile or collect and remain skipped unless Azure environment variables are configured
- `git diff --check`