### PR TITLE
Use Bicep Testing Framework name consistently

### DIFF
--- a/packages/go/README.md
+++ b/packages/go/README.md
@@ -1,4 +1,4 @@
-# Bicep Testing for Go
+# Bicep Testing Framework for Go
 
 Test the resources, outputs, and diagnostics produced by a Bicep deployment without deploying to Azure. The package can also run opt-in integration tests against a real Azure Deployment Stack when an assertion requires live resources.
 

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -1,4 +1,4 @@
-# Bicep Testing for Python
+# Bicep Testing Framework for Python
 
 Test the resources, outputs, and diagnostics produced by a Bicep deployment without deploying to Azure. The package can also run opt-in integration tests against a real Azure Deployment Stack when an assertion requires live resources.
 

--- a/site/index.html
+++ b/site/index.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Language-native test libraries for inspecting Bicep deployment snapshots and running live Azure tests." />
     <meta name="theme-color" content="#171a1f" />
-    <meta property="og:title" content="Bicep Testing" />
+    <meta property="og:title" content="Bicep Testing Framework" />
     <meta property="og:description" content="Test Bicep infrastructure before it reaches Azure." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://anthony-c-martin.github.io/bicep-testing/" />
     <meta property="og:image" content="https://anthony-c-martin.github.io/bicep-testing/bicep-logo.svg" />
-    <title>Bicep Testing</title>
+    <title>Bicep Testing Framework</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&amp;family=Manrope:wght@400;500;600;700;800&amp;display=swap" rel="stylesheet" />

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -215,7 +215,7 @@ export default function App() {
             width="34"
             height="34"
           />
-          <span>Bicep Testing</span>
+          <span>Bicep Testing Framework</span>
         </a>
         <nav aria-label="Primary navigation">
           <a href="#install">Install</a>
@@ -362,9 +362,8 @@ export default function App() {
             width="28"
             height="28"
           />
-          <span>Bicep Testing</span>
+          <span>Bicep Testing Framework</span>
         </a>
-        <p>Independent, non-official testing libraries for Bicep.</p>
         <div>
           <a href={`${repositoryUrl}/blob/main/LICENSE`}>MIT License</a>
           <a href={`${repositoryUrl}/issues`}>Issues</a>

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -484,7 +484,7 @@ svg {
 }
 footer {
   display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: 1fr 1fr;
   align-items: center;
   gap: 24px;
   padding: 36px var(--gutter);
@@ -494,10 +494,6 @@ footer {
 }
 footer .brand {
   color: white;
-}
-footer p {
-  margin: 0;
-  text-align: center;
 }
 footer > div {
   display: flex;
@@ -521,12 +517,6 @@ footer a {
   }
   .section-heading > p:last-child {
     grid-column: 2;
-  }
-  footer {
-    grid-template-columns: 1fr 1fr;
-  }
-  footer p {
-    display: none;
   }
 }
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary

- use “Bicep Testing Framework” consistently in the site header, footer, browser title, and Open Graph metadata
- remove the redundant “Independent, non-official testing libraries for Bicep.” footer copy
- update Go and Python package README titles to use the full framework name
- rebalance the footer layout after removing the center copy

## Validation

- `npm run format:check`
- `npm run build`
- `git diff --check`