### PR TITLE
Fix GitHub Pages site build

### DIFF
--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, type KeyboardEvent } from "react";
-import { ArrowDown, ArrowUpRight, Check, Copy, Github } from "lucide-react";
+import { ArrowDown, ArrowUpRight, Check, Copy, GitFork } from "lucide-react";
 import hljs from "highlight.js/lib/core";
 import csharp from "highlight.js/lib/languages/csharp";
 import go from "highlight.js/lib/languages/go";
@@ -221,7 +221,7 @@ export default function App() {
           <a href="#install">Install</a>
           <a href="#samples">Samples</a>
           <a className="github-link" href={repositoryUrl}>
-            <Github />
+            <GitFork />
             <span>GitHub</span>
           </a>
         </nav>


### PR DESCRIPTION
## Summary

- replace the removed `lucide-react` `Github` export with the available `GitFork` icon
- restore TypeScript compilation for the GitHub Pages site

## Validation

- `cd site && npm ci && npm run build`
- `git diff --check`

The Pages workflow previously failed with `TS2305: Module 'lucide-react' has no exported member 'Github'`.