### PR TITLE
Add language-specific getting started guides

### DIFF
--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -1,41 +1,27 @@
 import { useState, type KeyboardEvent } from "react";
-import { ArrowDown, ArrowUpRight, Check, Copy, GitFork } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUpRight,
+  Check,
+  Cloud,
+  Copy,
+  FileCode2,
+  GitFork,
+  Terminal,
+} from "lucide-react";
 import hljs from "highlight.js/lib/core";
 import csharp from "highlight.js/lib/languages/csharp";
 import go from "highlight.js/lib/languages/go";
 import javascript from "highlight.js/lib/languages/javascript";
 import powershell from "highlight.js/lib/languages/powershell";
 import python from "highlight.js/lib/languages/python";
-import nodeOffline from "../../samples/node/snapshot.test.js?raw";
-import nodeLive from "../../samples/node/deployment.test.js?raw";
-import csharpOffline from "../../samples/dotnet/OfflineTests.cs?raw";
-import csharpLive from "../../samples/dotnet/LiveTests.cs?raw";
-import goOffline from "../../samples/go/snapshot_test.go?raw";
-import goLive from "../../samples/go/deployment_test.go?raw";
-import powershellOffline from "../../samples/powershell/BicepTest.Sample.Tests.ps1?raw";
-import powershellLive from "../../samples/powershell/BicepTest.Deployment.Sample.Tests.ps1?raw";
-import pythonOffline from "../../samples/python/test_snapshot.py?raw";
-import pythonLive from "../../samples/python/test_deployment.py?raw";
-
-const repositoryUrl = "https://github.com/anthony-c-martin/bicep-testing";
-
-type LanguageId = "node" | "csharp" | "go" | "powershell" | "python";
-type SampleKind = "offline" | "live";
-
-interface LanguageSample {
-  id: LanguageId;
-  label: string;
-  highlightLanguage: string;
-  packageManager: string;
-  runtime: string;
-  install: string;
-  registry: string;
-  packageUrl: string;
-  offlineName: string;
-  liveName: string;
-  offline: string;
-  live: string;
-}
+import {
+  getLanguage,
+  languages,
+  repositoryUrl,
+  type LanguageId,
+  type StarterKind,
+} from "./languages";
 
 interface LanguageTabsProps {
   selected: LanguageId;
@@ -53,86 +39,6 @@ hljs.registerLanguage("go", go);
 hljs.registerLanguage("javascript", javascript);
 hljs.registerLanguage("powershell", powershell);
 hljs.registerLanguage("python", python);
-
-const languages: readonly LanguageSample[] = [
-  {
-    id: "node",
-    label: "Node",
-    highlightLanguage: "javascript",
-    packageManager: "npm",
-    runtime: "Node.js 22+",
-    install: "npm install --save-dev @anthony-c-martin/bicep-testing",
-    registry: "npm",
-    packageUrl: "https://www.npmjs.com/package/@anthony-c-martin/bicep-testing",
-    offlineName: "snapshot.test.js",
-    liveName: "deployment.test.js",
-    offline: nodeOffline,
-    live: nodeLive,
-  },
-  {
-    id: "csharp",
-    label: "C#",
-    highlightLanguage: "csharp",
-    packageManager: "NuGet",
-    runtime: ".NET 10+",
-    install: "dotnet add package AnthonyCMartin.BicepTesting",
-    registry: "NuGet",
-    packageUrl: "https://www.nuget.org/packages/AnthonyCMartin.BicepTesting",
-    offlineName: "OfflineTests.cs",
-    liveName: "LiveTests.cs",
-    offline: csharpOffline,
-    live: csharpLive,
-  },
-  {
-    id: "go",
-    label: "Go",
-    highlightLanguage: "go",
-    packageManager: "Go modules",
-    runtime: "Go 1.25+",
-    install:
-      "go get github.com/anthony-c-martin/bicep-testing/packages/go/bicep-testing",
-    registry: "pkg.go.dev",
-    packageUrl:
-      "https://pkg.go.dev/github.com/anthony-c-martin/bicep-testing/packages/go/bicep-testing",
-    offlineName: "snapshot_test.go",
-    liveName: "deployment_test.go",
-    offline: goOffline,
-    live: goLive,
-  },
-  {
-    id: "powershell",
-    label: "PowerShell",
-    highlightLanguage: "powershell",
-    packageManager: "PSGallery",
-    runtime: "PowerShell 7.6+",
-    install: "Install-PSResource AnthonyCMartin.BicepTesting",
-    registry: "PowerShell Gallery",
-    packageUrl:
-      "https://www.powershellgallery.com/packages/AnthonyCMartin.BicepTesting",
-    offlineName: "BicepTest.Sample.Tests.ps1",
-    liveName: "BicepTest.Deployment.Sample.Tests.ps1",
-    offline: powershellOffline,
-    live: powershellLive,
-  },
-  {
-    id: "python",
-    label: "Python",
-    highlightLanguage: "python",
-    packageManager: "PyPI",
-    runtime: "Python 3.11+",
-    install: "python -m pip install anthonycmartin-bicep-testing",
-    registry: "PyPI",
-    packageUrl: "https://pypi.org/project/anthonycmartin-bicep-testing/",
-    offlineName: "test_snapshot.py",
-    liveName: "test_deployment.py",
-    offline: pythonOffline,
-    live: pythonLive,
-  },
-];
-
-function getLanguage(id: LanguageId): LanguageSample {
-  return languages.find((language) => language.id === id)!;
-}
 
 function highlight(code: string, language: string): string {
   return hljs.highlight(code, { language }).value;
@@ -199,12 +105,14 @@ function CopyButton({ value, label }: CopyButtonProps) {
 
 export default function App() {
   const [selectedLanguage, setSelectedLanguage] = useState<LanguageId>("node");
-  const [sampleKind, setSampleKind] = useState<SampleKind>("offline");
+  const [starterKind, setStarterKind] = useState<StarterKind>("offline");
   const language = getLanguage(selectedLanguage);
-  const sampleCode = language[sampleKind];
-  const sampleName =
-    sampleKind === "offline" ? language.offlineName : language.liveName;
-  const highlightedSample = highlight(sampleCode, language.highlightLanguage);
+  const starterCode = {
+    offline: language.offlineStarter,
+    liveValidate: language.liveValidateStarter,
+    liveDeploy: language.liveDeployStarter,
+  }[starterKind];
+  const highlightedStarter = highlight(starterCode, language.highlightLanguage);
 
   return (
     <>
@@ -220,6 +128,7 @@ export default function App() {
         </a>
         <nav aria-label="Primary navigation">
           <a href="#install">Install</a>
+          <a href="#getting-started">Getting started</a>
           <a href="#samples">Samples</a>
           <a className="github-link" href={repositoryUrl}>
             <GitFork />
@@ -238,7 +147,8 @@ export default function App() {
               <p className="hero-lede">
                 Language-native libraries for testing Bicep files from Jest,
                 MSTest, Go testing, Pester, or pytest. Tests can inspect planned
-                infrastructure locally or validate and deploy resources in Azure.
+                infrastructure locally or validate and deploy resources in
+                Azure.
               </p>
               <div className="hero-actions">
                 <a className="button button-primary" href="#install">
@@ -274,9 +184,7 @@ export default function App() {
                 <strong>Viewing examples</strong>
                 <p>
                   Choose a language in the selector below. The install command,
-                  guide link, and inline source all update together. Open the
-                  Samples section and switch between Offline and Live to
-                  compare both test styles.
+                  quickstarts, guide link, and sample links all update together.
                 </p>
               </div>
             </div>
@@ -322,36 +230,122 @@ export default function App() {
             </div>
           </div>
         </section>
+        <section className="getting-started-section" id="getting-started">
+          <div className="section-heading">
+            <p className="section-kicker">Getting started</p>
+            <h2>From package to first assertion</h2>
+            <p>
+              Start offline with no Azure credentials, then switch to a live
+              validation when the template needs an Azure preflight check.
+            </p>
+          </div>
+          <div className="getting-started-layout">
+            <ol className="getting-started-steps">
+              <li>
+                <Terminal aria-hidden="true" />
+                <div>
+                  <span>01</span>
+                  <strong>Install for {language.label}</strong>
+                  <code>{language.install}</code>
+                </div>
+              </li>
+              <li>
+                <FileCode2 aria-hidden="true" />
+                <div>
+                  <span>02</span>
+                  <strong>Create a test</strong>
+                  <p>
+                    Point the session at a checked-in <code>.bicepparam</code>{" "}
+                    file.
+                  </p>
+                </div>
+              </li>
+              <li>
+                <Cloud aria-hidden="true" />
+                <div>
+                  <span>03</span>
+                  <strong>Run it natively</strong>
+                  <code>{language.testCommand}</code>
+                </div>
+              </li>
+            </ol>
+            <div className="starter-workbench">
+              <div className="starter-toolbar">
+                <div
+                  className="kind-switch"
+                  aria-label="Getting started test type"
+                >
+                  <button
+                    type="button"
+                    className={starterKind === "offline" ? "active" : ""}
+                    onClick={() => setStarterKind("offline")}
+                  >
+                    Offline
+                  </button>
+                  <button
+                    type="button"
+                    className={starterKind === "liveValidate" ? "active" : ""}
+                    onClick={() => setStarterKind("liveValidate")}
+                  >
+                    Live (Validate)
+                  </button>
+                  <button
+                    type="button"
+                    className={starterKind === "liveDeploy" ? "active" : ""}
+                    onClick={() => setStarterKind("liveDeploy")}
+                  >
+                    Live (Deploy)
+                  </button>
+                </div>
+                <span>{language.label} quickstart</span>
+                <CopyButton
+                  value={starterCode}
+                  label={`Copy ${language.label} ${starterKind} quickstart`}
+                />
+              </div>
+              <pre className="starter-code">
+                <code
+                  dangerouslySetInnerHTML={{ __html: highlightedStarter }}
+                />
+              </pre>
+              <a className="starter-guide-link" href={language.guideUrl}>
+                Read the complete {language.label} guide <ArrowUpRight />
+              </a>
+            </div>
+          </div>
+        </section>
         <section className="samples-section" id="samples">
           <div className="section-heading">
             <p className="section-kicker">Runnable samples</p>
-            <h2>The tests, in full</h2>
-            <p>These are real, working test samples you can run yourself.</p>
+            <h2>Explore the complete tests</h2>
+            <p>
+              Open the real {language.label} test files in GitHub to see the
+              complete setup, assertions, and cleanup flow.
+            </p>
           </div>
-          <div className="sample-workbench">
-            <div className="sample-toolbar">
-              <div className="kind-switch" aria-label="Sample type">
-                <button
-                  type="button"
-                  className={sampleKind === "offline" ? "active" : ""}
-                  onClick={() => setSampleKind("offline")}
-                >
-                  Offline
-                </button>
-                <button
-                  type="button"
-                  className={sampleKind === "live" ? "active" : ""}
-                  onClick={() => setSampleKind("live")}
-                >
-                  Live
-                </button>
-              </div>
-              <span className="file-name">{sampleName}</span>
-              <CopyButton value={sampleCode} label={`Copy ${sampleName}`} />
-            </div>
-            <pre className="sample-code">
-              <code dangerouslySetInnerHTML={{ __html: highlightedSample }} />
-            </pre>
+          <div className="sample-links">
+            <a href={language.offlineSampleUrl}>
+              <span>01 / Offline</span>
+              <strong>Local snapshot tests</strong>
+              <p>
+                Inspect predicted resources, outputs, and diagnostics without
+                Azure credentials.
+              </p>
+              <span className="sample-link-action">
+                View on GitHub <ArrowUpRight />
+              </span>
+            </a>
+            <a href={language.liveSampleUrl}>
+              <span>02 / Live</span>
+              <strong>Azure validation and deployment tests</strong>
+              <p>
+                Validate against Azure, deploy real resources, assert behavior,
+                and tear everything down.
+              </p>
+              <span className="sample-link-action">
+                View on GitHub <ArrowUpRight />
+              </span>
+            </a>
           </div>
         </section>
       </main>

--- a/site/src/languages/constants.ts
+++ b/site/src/languages/constants.ts
@@ -1,0 +1,4 @@
+export const repositoryUrl =
+  "https://github.com/anthony-c-martin/bicep-testing";
+export const fakeTenantId = "ddbe463a-0554-485d-b589-0b17d60cd38b";
+export const fakeSubscriptionId = "28c9069e-23e8-47d2-b640-00d2e0f09616";

--- a/site/src/languages/csharp.ts
+++ b/site/src/languages/csharp.ts
@@ -1,0 +1,69 @@
+import { fakeSubscriptionId, fakeTenantId, repositoryUrl } from "./constants";
+import type { LanguageSample } from "./types";
+
+export const csharp: LanguageSample = {
+  id: "csharp",
+  label: "C#",
+  highlightLanguage: "csharp",
+  packageManager: "NuGet",
+  runtime: ".NET 10+",
+  install: "dotnet add package AnthonyCMartin.BicepTesting",
+  registry: "NuGet",
+  packageUrl: "https://www.nuget.org/packages/AnthonyCMartin.BicepTesting",
+  guideUrl: `${repositoryUrl}/blob/main/packages/dotnet/README.md`,
+  testCommand: "dotnet test",
+  offlineStarter: `using AnthonyCMartin.BicepTesting;
+
+[TestMethod]
+public async Task Template_compiles_without_diagnostics()
+{
+    await using var session = await BicepTestSession.CreateAsync("0.46.1");
+    var snapshot = await session.SnapshotAsync(new SnapshotOptions
+    {
+        FilePath = "infra/main.bicepparam",
+        TenantId = "${fakeTenantId}",
+        SubscriptionId = "${fakeSubscriptionId}",
+        ResourceGroup = "example-rg",
+        Location = "eastus",
+    });
+
+    Assert.IsEmpty(snapshot.Diagnostics);
+}`,
+  liveValidateStarter: `using AnthonyCMartin.BicepTesting;
+  using Azure.Identity;
+
+  await using var session = await LiveBicepTestSession.CreateAsync(
+    "0.46.1",
+    new DefaultAzureCredential());
+  var validation = await session.ValidateAsync(new DeployOptions
+  {
+    FilePath = "infra/main.bicepparam",
+    SubscriptionId = subscriptionId,
+    ResourceGroup = resourceGroup,
+  });
+
+  Assert.IsTrue(validation.IsValid, validation.ErrorMessage);`,
+  liveDeployStarter: `using AnthonyCMartin.BicepTesting;
+  using Azure.Identity;
+
+  await using var session = await LiveBicepTestSession.CreateAsync(
+    "0.46.1",
+    new DefaultAzureCredential());
+  var deployment = await session.DeployAsync(new DeployOptions
+  {
+    FilePath = "infra/main.bicepparam",
+    SubscriptionId = subscriptionId,
+    ResourceGroup = resourceGroup,
+  });
+
+  try
+  {
+    Assert.IsTrue(deployment.Succeeded, deployment.ErrorMessage);
+  }
+  finally
+  {
+    await deployment.TeardownAsync();
+  }`,
+  offlineSampleUrl: `${repositoryUrl}/blob/main/samples/dotnet/OfflineTests.cs`,
+  liveSampleUrl: `${repositoryUrl}/blob/main/samples/dotnet/LiveTests.cs`,
+};

--- a/site/src/languages/go.ts
+++ b/site/src/languages/go.ts
@@ -1,0 +1,70 @@
+import { fakeSubscriptionId, fakeTenantId, repositoryUrl } from "./constants";
+import type { LanguageSample } from "./types";
+
+export const go: LanguageSample = {
+  id: "go",
+  label: "Go",
+  highlightLanguage: "go",
+  packageManager: "Go modules",
+  runtime: "Go 1.25+",
+  install:
+    "go get github.com/anthony-c-martin/bicep-testing/packages/go/bicep-testing",
+  registry: "pkg.go.dev",
+  packageUrl:
+    "https://pkg.go.dev/github.com/anthony-c-martin/bicep-testing/packages/go/bicep-testing",
+  guideUrl: `${repositoryUrl}/blob/main/packages/go/bicep-testing/README.md`,
+  testCommand: "go test ./...",
+  offlineStarter: `func TestTemplateCompilesWithoutDiagnostics(t *testing.T) {
+  ctx := context.Background()
+  session, err := biceptesting.NewSession(ctx, "0.46.1")
+  if err != nil { t.Fatal(err) }
+  t.Cleanup(func() { _ = session.Close() })
+
+  snapshot, err := session.Snapshot(ctx, "infra/main.bicepparam",
+    biceptesting.SnapshotMetadata{
+      TenantID:       "${fakeTenantId}",
+      SubscriptionID: "${fakeSubscriptionId}",
+      ResourceGroup:  "example-rg",
+      Location:       "eastus",
+    })
+  if err != nil { t.Fatal(err) }
+  if len(snapshot.Diagnostics) != 0 {
+    t.Fatalf("got diagnostics: %v", snapshot.Diagnostics)
+  }
+}`,
+  liveValidateStarter: `credential, err := azidentity.NewDefaultAzureCredential(nil)
+if err != nil { t.Fatal(err) }
+
+session, err := biceptesting.NewLiveSession(ctx, "0.46.1", credential)
+if err != nil { t.Fatal(err) }
+defer session.Close()
+
+validation, err := session.Validate(ctx, biceptesting.DeployOptions{
+  FilePath:       "infra/main.bicepparam",
+  SubscriptionID: os.Getenv("AZURE_SUBSCRIPTION_ID"),
+  ResourceGroup:  os.Getenv("AZURE_RESOURCE_GROUP"),
+})
+if err != nil { t.Fatal(err) }
+if !validation.IsValid { t.Fatal(validation.ErrorMessage) }`,
+  liveDeployStarter: `credential, err := azidentity.NewDefaultAzureCredential(nil)
+if err != nil { t.Fatal(err) }
+
+session, err := biceptesting.NewLiveSession(ctx, "0.46.1", credential)
+if err != nil { t.Fatal(err) }
+defer session.Close()
+
+deployment, err := session.Deploy(ctx, biceptesting.DeployOptions{
+  FilePath:       "infra/main.bicepparam",
+  SubscriptionID: os.Getenv("AZURE_SUBSCRIPTION_ID"),
+  ResourceGroup:  os.Getenv("AZURE_RESOURCE_GROUP"),
+})
+if err != nil { t.Fatal(err) }
+defer func() {
+  if err := deployment.Teardown(context.Background()); err != nil {
+    t.Errorf("teardown: %v", err)
+  }
+}()
+if !deployment.Succeeded { t.Fatal(deployment.ErrorMessage) }`,
+  offlineSampleUrl: `${repositoryUrl}/blob/main/samples/go/snapshot_test.go`,
+  liveSampleUrl: `${repositoryUrl}/blob/main/samples/go/deployment_test.go`,
+};

--- a/site/src/languages/index.ts
+++ b/site/src/languages/index.ts
@@ -1,0 +1,21 @@
+import { csharp } from "./csharp";
+import { go } from "./go";
+import { node } from "./node";
+import { powershell } from "./powershell";
+import { python } from "./python";
+import type { LanguageId, LanguageSample } from "./types";
+
+export { repositoryUrl } from "./constants";
+export type { LanguageId, LanguageSample, StarterKind } from "./types";
+
+export const languages: readonly LanguageSample[] = [
+  node,
+  csharp,
+  go,
+  powershell,
+  python,
+];
+
+export function getLanguage(id: LanguageId): LanguageSample {
+  return languages.find((language) => language.id === id)!;
+}

--- a/site/src/languages/node.ts
+++ b/site/src/languages/node.ts
@@ -1,0 +1,70 @@
+import { fakeSubscriptionId, fakeTenantId, repositoryUrl } from "./constants";
+import type { LanguageSample } from "./types";
+
+export const node: LanguageSample = {
+  id: "node",
+  label: "Node",
+  highlightLanguage: "javascript",
+  packageManager: "npm",
+  runtime: "Node.js 22+",
+  install: "npm install --save-dev @anthony-c-martin/bicep-testing",
+  registry: "npm",
+  packageUrl: "https://www.npmjs.com/package/@anthony-c-martin/bicep-testing",
+  guideUrl: `${repositoryUrl}/blob/main/packages/node/README.md`,
+  testCommand: "npm test",
+  offlineStarter: `const { BicepTestSession } = require('@anthony-c-martin/bicep-testing');
+
+test('template compiles without diagnostics', async () => {
+  const session = await BicepTestSession.create('0.46.1');
+  try {
+    const snapshot = await session.snapshot(
+      'infra/main.bicepparam',
+      '${fakeTenantId}',
+      '${fakeSubscriptionId}',
+      'example-rg',
+      'eastus',
+    );
+    expect(snapshot.diagnostics).toHaveLength(0);
+  } finally {
+    session.dispose();
+  }
+});`,
+  liveValidateStarter: `const { DefaultAzureCredential } = require('@azure/identity');
+const { LiveBicepTestSession } = require('@anthony-c-martin/bicep-testing');
+
+const session = await LiveBicepTestSession.create(
+  '0.46.1',
+  new DefaultAzureCredential(),
+);
+try {
+  const validation = await session.validate({
+    filePath: 'infra/main.bicepparam',
+    subscriptionId: process.env.AZURE_SUBSCRIPTION_ID,
+    resourceGroup: process.env.AZURE_RESOURCE_GROUP,
+  });
+  expect(validation.isValid).toBe(true);
+} finally {
+  session.dispose();
+}`,
+  liveDeployStarter: `const { DefaultAzureCredential } = require('@azure/identity');
+const { LiveBicepTestSession } = require('@anthony-c-martin/bicep-testing');
+
+const session = await LiveBicepTestSession.create(
+  '0.46.1',
+  new DefaultAzureCredential(),
+);
+let deployment;
+try {
+  deployment = await session.deploy({
+    filePath: 'infra/main.bicepparam',
+    subscriptionId: process.env.AZURE_SUBSCRIPTION_ID,
+    resourceGroup: process.env.AZURE_RESOURCE_GROUP,
+  });
+  expect(deployment.succeeded).toBe(true);
+} finally {
+  await deployment?.teardown();
+  session.dispose();
+}`,
+  offlineSampleUrl: `${repositoryUrl}/blob/main/samples/node/snapshot.test.js`,
+  liveSampleUrl: `${repositoryUrl}/blob/main/samples/node/deployment.test.js`,
+};

--- a/site/src/languages/powershell.ts
+++ b/site/src/languages/powershell.ts
@@ -1,0 +1,69 @@
+import { fakeSubscriptionId, fakeTenantId, repositoryUrl } from "./constants";
+import type { LanguageSample } from "./types";
+
+const powershellContinuation = "`";
+
+export const powershell: LanguageSample = {
+  id: "powershell",
+  label: "PowerShell",
+  highlightLanguage: "powershell",
+  packageManager: "PSGallery",
+  runtime: "PowerShell 7.6+",
+  install: "Install-PSResource AnthonyCMartin.BicepTesting",
+  registry: "PowerShell Gallery",
+  packageUrl:
+    "https://www.powershellgallery.com/packages/AnthonyCMartin.BicepTesting",
+  guideUrl: `${repositoryUrl}/blob/main/packages/powershell/README.md`,
+  testCommand: "Invoke-Pester",
+  offlineStarter: `Describe 'Bicep template' {
+    BeforeAll {
+        $session = New-BicepTestSession -BicepVersion '0.46.1'
+    }
+
+    AfterAll { $session | Remove-BicepTestSession }
+
+    It 'compiles without diagnostics' {
+        $snapshot = $session | Get-BicepSnapshot ${powershellContinuation}
+            -Path 'infra/main.bicepparam' ${powershellContinuation}
+            -TenantId '${fakeTenantId}' ${powershellContinuation}
+            -SubscriptionId '${fakeSubscriptionId}' ${powershellContinuation}
+            -ResourceGroup 'example-rg' ${powershellContinuation}
+            -Location 'eastus'
+        $snapshot.Diagnostics | Should -BeNullOrEmpty
+    }
+}`,
+  liveValidateStarter: `$session = New-BicepLiveTestSession ${powershellContinuation}
+    -BicepVersion '0.46.1' ${powershellContinuation}
+    -Credential ([Azure.Identity.DefaultAzureCredential]::new())
+
+try {
+    $validation = $session | Test-BicepTestDeployment ${powershellContinuation}
+        -Path 'infra/main.bicepparam' ${powershellContinuation}
+        -SubscriptionId $env:AZURE_SUBSCRIPTION_ID ${powershellContinuation}
+        -ResourceGroup $env:AZURE_RESOURCE_GROUP
+
+    $validation.IsValid | Should -BeTrue
+}
+finally {
+    $session | Remove-BicepTestSession
+}`,
+  liveDeployStarter: `$session = New-BicepLiveTestSession ${powershellContinuation}
+    -BicepVersion '0.46.1' ${powershellContinuation}
+    -Credential ([Azure.Identity.DefaultAzureCredential]::new())
+
+$deployment = $null
+try {
+    $deployment = $session | Start-BicepTestDeployment ${powershellContinuation}
+        -Path 'infra/main.bicepparam' ${powershellContinuation}
+        -SubscriptionId $env:AZURE_SUBSCRIPTION_ID ${powershellContinuation}
+        -ResourceGroup $env:AZURE_RESOURCE_GROUP
+
+    $deployment.Succeeded | Should -BeTrue
+}
+finally {
+    if ($deployment) { $deployment | Remove-BicepTestDeployment }
+    $session | Remove-BicepTestSession
+}`,
+  offlineSampleUrl: `${repositoryUrl}/blob/main/samples/powershell/BicepTest.Sample.Tests.ps1`,
+  liveSampleUrl: `${repositoryUrl}/blob/main/samples/powershell/BicepTest.Deployment.Sample.Tests.ps1`,
+};

--- a/site/src/languages/python.ts
+++ b/site/src/languages/python.ts
@@ -1,0 +1,61 @@
+import { fakeSubscriptionId, fakeTenantId, repositoryUrl } from "./constants";
+import type { LanguageSample } from "./types";
+
+export const python: LanguageSample = {
+  id: "python",
+  label: "Python",
+  highlightLanguage: "python",
+  packageManager: "PyPI",
+  runtime: "Python 3.11+",
+  install: "python -m pip install anthonycmartin-bicep-testing",
+  registry: "PyPI",
+  packageUrl: "https://pypi.org/project/anthonycmartin-bicep-testing/",
+  guideUrl: `${repositoryUrl}/blob/main/packages/python/bicep_testing/README.md`,
+  testCommand: "python -m pytest",
+  offlineStarter: `from anthonycmartin.bicep_testing import BicepTestSession, SnapshotMetadata
+
+def test_template_compiles_without_diagnostics():
+    metadata = SnapshotMetadata(
+        tenant_id="${fakeTenantId}",
+        subscription_id="${fakeSubscriptionId}",
+        resource_group="example-rg",
+        location="eastus",
+    )
+    with BicepTestSession.create("0.46.1") as session:
+        snapshot = session.snapshot("infra/main.bicepparam", metadata)
+
+    assert snapshot.diagnostics == ()`,
+  liveValidateStarter: `from azure.identity import DefaultAzureCredential
+from anthonycmartin.bicep_testing import (
+    LiveBicepTestSession,
+    ResourceGroupDeployOptions,
+)
+
+with LiveBicepTestSession.create(
+    "0.46.1", DefaultAzureCredential()
+) as session:
+    validation = session.validate(ResourceGroupDeployOptions(
+        file_path="infra/main.bicepparam",
+        subscription_id=subscription_id,
+        resource_group=resource_group,
+    ))
+    assert validation.is_valid`,
+  liveDeployStarter: `from azure.identity import DefaultAzureCredential
+from anthonycmartin.bicep_testing import (
+    LiveBicepTestSession,
+    ResourceGroupDeployOptions,
+)
+
+with LiveBicepTestSession.create(
+    "0.46.1", DefaultAzureCredential()
+) as session:
+    options = ResourceGroupDeployOptions(
+        file_path="infra/main.bicepparam",
+        subscription_id=subscription_id,
+        resource_group=resource_group,
+    )
+    with session.deploy(options) as deployment:
+        assert deployment.succeeded`,
+  offlineSampleUrl: `${repositoryUrl}/blob/main/samples/python/test_snapshot.py`,
+  liveSampleUrl: `${repositoryUrl}/blob/main/samples/python/test_deployment.py`,
+};

--- a/site/src/languages/types.ts
+++ b/site/src/languages/types.ts
@@ -1,0 +1,20 @@
+export type LanguageId = "node" | "csharp" | "go" | "powershell" | "python";
+export type StarterKind = "offline" | "liveValidate" | "liveDeploy";
+
+export interface LanguageSample {
+  id: LanguageId;
+  label: string;
+  highlightLanguage: string;
+  packageManager: string;
+  runtime: string;
+  install: string;
+  registry: string;
+  packageUrl: string;
+  guideUrl: string;
+  testCommand: string;
+  offlineStarter: string;
+  liveValidateStarter: string;
+  liveDeployStarter: string;
+  offlineSampleUrl: string;
+  liveSampleUrl: string;
+}

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -251,6 +251,7 @@ svg {
   font-size: 13px;
 }
 .install-section,
+.getting-started-section,
 .samples-section {
   width: var(--content);
   margin: auto;
@@ -376,6 +377,107 @@ svg {
   font-weight: 700;
   text-decoration: none;
 }
+.getting-started-section {
+  border-top: 1px solid var(--line);
+}
+.getting-started-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.68fr) minmax(0, 1.32fr);
+  gap: 54px;
+  align-items: start;
+}
+.getting-started-steps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid var(--line);
+}
+.getting-started-steps li {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 14px;
+  padding: 22px 0;
+  border-bottom: 1px solid var(--line);
+}
+.getting-started-steps li > svg {
+  width: 22px;
+  height: 22px;
+  margin-top: 3px;
+  color: var(--azure);
+}
+.getting-started-steps li > div {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+.getting-started-steps span {
+  color: var(--muted);
+  font:
+    600 10px "IBM Plex Mono",
+    monospace;
+}
+.getting-started-steps strong {
+  font-size: 15px;
+}
+.getting-started-steps p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+.getting-started-steps code {
+  overflow-wrap: anywhere;
+  color: var(--ink-soft);
+  font-size: 11px;
+}
+.starter-workbench {
+  overflow: hidden;
+  border: 1px solid #3c424a;
+  border-radius: 6px;
+  background: #191d22;
+  box-shadow: 0 20px 55px rgba(24, 33, 39, 0.12);
+}
+.starter-toolbar {
+  display: grid;
+  grid-template-columns: auto 1fr 50px;
+  align-items: center;
+  min-height: 58px;
+  color: var(--white);
+  border-bottom: 1px solid #3b4149;
+}
+.starter-toolbar > span {
+  justify-self: end;
+  padding: 0 18px;
+  color: #8f98a1;
+  font:
+    11px "IBM Plex Mono",
+    monospace;
+}
+.starter-toolbar .icon-button {
+  height: 100%;
+}
+.starter-code {
+  min-height: 330px;
+  max-height: 500px;
+  margin: 0;
+  overflow: auto;
+  padding: 28px;
+  color: #d9e5e9;
+  font-size: 11px;
+  line-height: 1.72;
+  tab-size: 2;
+}
+.starter-guide-link {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 7px;
+  padding: 15px 20px;
+  color: var(--mint);
+  border-top: 1px solid #3b4149;
+  font-size: 12px;
+  font-weight: 700;
+  text-decoration: none;
+}
 .samples-section {
   width: 100%;
   padding-right: var(--gutter);
@@ -388,18 +490,6 @@ svg {
 }
 .samples-section .section-heading > p:last-child {
   color: #b7bec5;
-}
-.sample-workbench {
-  border: 1px solid #4a5059;
-  background: #191d22;
-  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.22);
-}
-.sample-toolbar {
-  display: grid;
-  grid-template-columns: auto 1fr 50px;
-  align-items: center;
-  min-height: 58px;
-  border-bottom: 1px solid #3b4149;
 }
 .kind-switch {
   display: flex;
@@ -421,26 +511,47 @@ svg {
   color: var(--ink);
   background: var(--mint);
 }
-.file-name {
-  justify-self: end;
-  padding: 0 18px;
-  color: #8f98a1;
-  font:
-    11px "IBM Plex Mono",
-    monospace;
+.sample-links {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-top: 1px solid #4a5059;
 }
-.sample-toolbar .icon-button {
-  height: 100%;
-}
-.sample-code {
-  max-height: 680px;
-  margin: 0;
-  overflow: auto;
+.sample-links > a {
+  display: grid;
+  grid-template-rows: auto auto 1fr auto;
+  gap: 12px;
+  min-height: 270px;
   padding: 32px;
-  color: #d9e5e9;
+  color: var(--white);
+  border-bottom: 1px solid #4a5059;
+  text-decoration: none;
+}
+.sample-links > a:first-child {
+  border-right: 1px solid #4a5059;
+}
+.sample-links > a > span:first-child {
+  color: #9fa7af;
+  font:
+    600 10px "IBM Plex Mono",
+    monospace;
+  text-transform: uppercase;
+}
+.sample-links strong {
+  font-size: 20px;
+  line-height: 1.3;
+}
+.sample-links p {
+  margin: 0;
+  color: #b7bec5;
+  font-size: 13px;
+}
+.sample-link-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--mint);
   font-size: 12px;
-  line-height: 1.75;
-  tab-size: 2;
+  font-weight: 700;
 }
 .hljs-comment,
 .hljs-quote {
@@ -518,6 +629,18 @@ footer a {
   .section-heading > p:last-child {
     grid-column: 2;
   }
+  .getting-started-layout {
+    grid-template-columns: 1fr;
+  }
+  .getting-started-steps {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .getting-started-steps li {
+    align-content: start;
+    padding: 20px 16px;
+    border-right: 1px solid var(--line);
+  }
 }
 @media (max-width: 640px) {
   .site-header {
@@ -589,7 +712,8 @@ footer a {
     margin-top: 22px;
     padding-top: 15px;
   }
-  .install-section {
+  .install-section,
+  .getting-started-section {
     width: calc(100% - 36px);
     padding: 76px 0;
   }
@@ -610,6 +734,33 @@ footer a {
   .install-panel {
     padding: 24px 18px;
   }
+  .getting-started-steps {
+    display: block;
+  }
+  .getting-started-steps li {
+    padding-right: 0;
+    padding-left: 0;
+    border-right: 0;
+  }
+  .starter-toolbar {
+    grid-template-columns: 1fr 48px;
+  }
+  .starter-toolbar .kind-switch {
+    gap: 2px;
+    padding: 6px;
+  }
+  .starter-toolbar .kind-switch button {
+    padding: 0 7px;
+    font-size: 10px;
+  }
+  .starter-toolbar > span {
+    display: none;
+  }
+  .starter-code {
+    min-height: 0;
+    padding: 22px 18px;
+    font-size: 10px;
+  }
   .command-row code {
     padding: 16px;
     font-size: 11px;
@@ -617,16 +768,15 @@ footer a {
   .samples-section {
     padding: 76px 18px;
   }
-  .sample-toolbar {
-    grid-template-columns: 1fr 48px;
+  .sample-links {
+    grid-template-columns: 1fr;
   }
-  .file-name {
-    display: none;
+  .sample-links > a {
+    min-height: 230px;
+    padding: 26px 20px;
   }
-  .sample-code {
-    max-height: 560px;
-    padding: 22px 18px;
-    font-size: 10px;
+  .sample-links > a:first-child {
+    border-right: 0;
   }
   footer {
     display: flex;


### PR DESCRIPTION
## Summary

Adds a language-aware Getting Started experience to the GitHub Pages site for Node, C#, Go, PowerShell, and Python.

## Highlights

- Adds idiomatic offline quickstarts with tenant, subscription, resource-group, and location evaluation context.
- Adds separate `Live (Validate)` and `Live (Deploy)` examples for every language.
- Demonstrates each ecosystem's native deployment cleanup pattern.
- Replaces bundled long-form sample source with direct links to the runnable tests in GitHub.
- Extracts language-specific metadata and code snippets from `App.tsx` into dedicated modules under `site/src/languages`.
- Keeps the selected language synchronized across installation, quickstarts, guides, and sample links.

## Validation

- `npm --prefix site run format`
- `npm --prefix site run build`
- `npm --prefix site run format:check`
- `git diff --check -- site/src`